### PR TITLE
Fix "--disable-flagging-jndi-lookup" flag

### DIFF
--- a/changelog/@unreleased/pr-58.v2.yml
+++ b/changelog/@unreleased/pr-58.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Fix "--disable-flagging-jndi-lookup" flag such that specifying the
+    flag properly ignores files that were flagged only because of the presence of
+    the JndiLookup class.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/58

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -110,11 +110,12 @@ func Crawl(ctx context.Context, config Config, stdout, stderr io.Writer) (int64,
 		IgnoreDirs:  config.Ignores,
 	}
 	reporter := crawl.Reporter{
-		OutputJSON:         config.OutputJSON,
-		OutputFilePathOnly: config.OutputFilePathOnly,
-		OutputWriter:       stdout,
-		DisableCVE45105:    config.DisableCVE45105,
-		DisableCVE44832:    config.DisableCVE44832,
+		OutputJSON:                config.OutputJSON,
+		OutputFilePathOnly:        config.OutputFilePathOnly,
+		OutputWriter:              stdout,
+		DisableCVE45105:           config.DisableCVE45105,
+		DisableCVE44832:           config.DisableCVE44832,
+		DisableFlaggingJndiLookup: config.DisableFlaggingJndiLookup,
 	}
 
 	crawlStats, err := crawler.Crawl(ctx, config.Root, identifier.Identify, reporter.Collect)

--- a/pkg/crawl/report.go
+++ b/pkg/crawl/report.go
@@ -172,11 +172,11 @@ func (r *Reporter) Collect(ctx context.Context, path string, d fs.DirEntry, resu
 
 	var readableReasons []string
 	var findingNames []string
-	if result&JndiLookupClassName > 0 {
+	if result&JndiLookupClassName > 0 && !r.DisableFlaggingJndiLookup {
 		readableReasons = append(readableReasons, "JndiLookup class name matched")
 		findingNames = append(findingNames, "jndiLookupClassName")
 	}
-	if result&JndiLookupClassPackageAndName > 0 {
+	if result&JndiLookupClassPackageAndName > 0 && !r.DisableFlaggingJndiLookup {
 		readableReasons = append(readableReasons, "JndiLookup class and package name matched")
 		findingNames = append(findingNames, "jndiLookupClassPackageAndName")
 	}


### PR DESCRIPTION
Flag was not properly hooked up, so specifying it had no effect.
Fixes the issue so that specifying the "--disable-flagging-jndi-lookup"
flag causes the crawl operation to properly ignore flagging issues
that are caused only by the presence of the JndiLookup class.