### PR TITLE
Add "--disable-unknown-versions" flag

### DIFF
--- a/changelog/@unreleased/pr-59.v2.yml
+++ b/changelog/@unreleased/pr-59.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Add "--disable-unknown-versions" flag
+
+    Adds flag for "crawl" operation that does not output any CVEs
+    for which the version cannot be determined.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/59

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -41,6 +41,7 @@ func crawlCmd() *cobra.Command {
 		disableCVE45105                    bool
 		disableCVE44832                    bool
 		disableFlaggingJndiLookup          bool
+		disableUnknownVersions             bool
 		outputJSON                         bool
 		outputFilePathOnly                 bool
 		outputSummary                      bool
@@ -89,6 +90,7 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 				DisableFlaggingJndiLookup:          disableFlaggingJndiLookup,
 				DisableCVE45105:                    disableCVE45105,
 				DisableCVE44832:                    disableCVE44832,
+				DisableUnknownVersions:             disableUnknownVersions,
 				Ignores:                            ignores,
 				OutputJSON:                         outputJSON,
 				OutputFilePathOnly:                 outputFilePathOnly,
@@ -119,6 +121,7 @@ A max depth of 0 will open up an archive on the filesystem but not any nested ar
 Even when disabled results which match other criteria will still report the presence of JndiLookup if relevant.`)
 	cmd.Flags().BoolVar(&disableCVE45105, "disable-cve-2021-45105-detection", false, `Disable detection of CVE-2021-45105 in versions up to 2.16.0`)
 	cmd.Flags().BoolVar(&disableCVE44832, "disable-cve-2021-44832-detection", false, `Disable detection of CVE-2021-44832 in versions up to 2.17.0`)
+	cmd.Flags().BoolVar(&disableUnknownVersions, "disable-unknown-versions", false, `Only output issues if the version of log4j can be determined (note that this will cause certain detection mechanisms to be skipped)`)
 	cmd.Flags().BoolVar(&outputJSON, "json", false, "If true, output will be in JSON format")
 	cmd.Flags().BoolVar(&outputFilePathOnly, "file-path-only", false, "If true, output will consist of only paths to the files in which CVEs are detected")
 	cmd.Flags().BoolVar(&outputSummary, "summary", true, "If true, outputs a summary of all operations once program completes")

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -56,6 +56,8 @@ type Config struct {
 	DisableCVE45105 bool
 	// If true, disables detection of CVE-2021-44832
 	DisableCVE44832 bool
+	// If true, does not report CVE unless the version of log4j can be determined
+	DisableUnknownVersions bool
 	// Ignores specifies the regular expressions used to determine which directories to omit.
 	Ignores []*regexp.Regexp
 	// If true, causes all output to be in JSON format (one JSON object per line).
@@ -110,12 +112,13 @@ func Crawl(ctx context.Context, config Config, stdout, stderr io.Writer) (int64,
 		IgnoreDirs:  config.Ignores,
 	}
 	reporter := crawl.Reporter{
-		OutputJSON:                config.OutputJSON,
-		OutputFilePathOnly:        config.OutputFilePathOnly,
-		OutputWriter:              stdout,
-		DisableCVE45105:           config.DisableCVE45105,
-		DisableCVE44832:           config.DisableCVE44832,
-		DisableFlaggingJndiLookup: config.DisableFlaggingJndiLookup,
+		OutputJSON:                     config.OutputJSON,
+		OutputFilePathOnly:             config.OutputFilePathOnly,
+		OutputWriter:                   stdout,
+		DisableCVE45105:                config.DisableCVE45105,
+		DisableCVE44832:                config.DisableCVE44832,
+		DisableFlaggingJndiLookup:      config.DisableFlaggingJndiLookup,
+		DisableFlaggingUnknownVersions: config.DisableUnknownVersions,
 	}
 
 	crawlStats, err := crawler.Crawl(ctx, config.Root, identifier.Identify, reporter.Collect)

--- a/pkg/crawl/report.go
+++ b/pkg/crawl/report.go
@@ -42,6 +42,8 @@ type Reporter struct {
 	DisableCVE45105 bool
 	// Disables detection of CVE-2021-44832
 	DisableCVE44832 bool
+	// Disables flagging issues where version of log4j is not known
+	DisableFlaggingUnknownVersions bool
 	// Number of issues that have been found
 	count int64
 }
@@ -154,6 +156,9 @@ var cveVersions = []AffectedVersion{
 // Collect increments the count of number of calls to Reporter.Collect and logs the path of the vulnerable file to disk.
 func (r *Reporter) Collect(ctx context.Context, path string, d fs.DirEntry, result Finding, versionSet Versions) {
 	versions := sortVersions(versionSet)
+	if r.DisableFlaggingUnknownVersions && (len(versions) == 0 || len(versions) == 1 && versions[0] == UnknownVersion) {
+		return
+	}
 	cvesFound := r.matchedCVEs(versions)
 	if len(cvesFound) == 0 {
 		return

--- a/pkg/crawl/report_test.go
+++ b/pkg/crawl/report_test.go
@@ -91,3 +91,13 @@ func TestFilePathOnlyOutput(t *testing.T) {
 	r.Collect(context.Background(), "test-name.jar", stubDirEntry{name: "test-name"}, crawl.JarName, crawl.Versions{"2.15.0": {}})
 	assert.Equal(t, "test-name.jar\n", buf.String())
 }
+
+func TestDisableFlaggingUnknownVersions(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := crawl.Reporter{
+		OutputWriter:                   buf,
+		DisableFlaggingUnknownVersions: true,
+	}
+	r.Collect(context.Background(), "test-name.jar", stubDirEntry{name: "test-name"}, crawl.JarName, crawl.Versions{crawl.UnknownVersion: {}})
+	assert.Equal(t, "", buf.String())
+}


### PR DESCRIPTION
Adds flag for "crawl" operation that does not output any CVEs
for which the version cannot be determined.