### PR TITLE
Only print walk error when not nil

### DIFF
--- a/changelog/@unreleased/pr-62.v2.yml
+++ b/changelog/@unreleased/pr-62.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: A small logging bug has been fixed where for nested archives, an error
+    log line would be emitted for all results, regardless of whether there was an
+    error or not.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/62


### PR DESCRIPTION
During the hefty rebase of https://github.com/palantir/log4j-sniffer/pull/47 I accidentally left a couple of log lines in the wrong place meaning we would log an error log line whenever a nested archive would be walked.

This PR fixes up those logs by:
* Removing error log on every nested archive walk, replacing it with the wrapping of a bubbled up error in the top level `Identify` method.
* Removing the `"Found finding in what appeared to be an obfuscated jar..."` log line, which lives at https://github.com/palantir/log4j-sniffer/blob/28f06a3198ff1aa0096dbdd49ffd6b5785e3184d/pkg/crawl/identify.go#L188 with the handling of obfuscated results. I've added an issue for handling obfuscation at nested levels.