### PR TITLE
Print skipped paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Output for vulnerable files looks as follows:
 [INFO] Found JndiLookup class in the log4j package at org/apache/logging/log4j/core/lookup/JndiLookup.class
 [MATCH] CVE-2021-44228, CVE-2021-45046, CVE-2021-45105, CVE-2021-44832 detected in file examples/single_bad_version/log4j-core-2.14.1.jar. log4j versions: 2.14.0-2.14.1, 2.14.1. Reasons: JndiLookup class and package name matched, jar name matched, JndiManager class and package name matched, class file MD5 matched
 Files affected by CVE-2021-44228 or CVE-2021-45046 or CVE-2021-45105 or CVE-2021-44832 detected: 1 file(s)
-1 total files scanned, skipped 0 paths due to permission denied errors, encountered 0 errors processing paths
+1 total files scanned, skipped identifying 0 files due to config, skipped 0 paths due to permission denied errors, encountered 0 errors processing paths
 ```
 
 Getting started
@@ -129,7 +129,7 @@ Here is an example of the output with `--json`:
 
 ```
 {"message":"CVE-2021-44832, CVE-2021-44228, CVE-2021-45046, CVE-2021-45105 detected","filePath":"examples/single_bad_version/log4j-core-2.14.1.jar","cvesDetected":["CVE-2021-44832","CVE-2021-44228","CVE-2021-45046","CVE-2021-45105"],"findings":["jndiLookupClassPackageAndName","jarName","jndiManagerClassPackageAndName","classFileMd5"],"log4jVersions":["2.14.0-2.14.1","2.14.1"]}
-{"filesScanned":1,"permissionDeniedErrors":0,"pathErrors":0,"numImpactedFiles":1}
+{"filesScanned":1,"permissionDeniedErrors":0,"pathErrors":0,"pathsSkipped":0,"numImpactedFiles":1}
 ```
 
 The JSON fields have the following meaning:
@@ -149,6 +149,13 @@ The findings array reports the following possible values:
 - classBytecodeInstructionMd5: the bytecode of a class file called `JndiManager` exactly matched a known version, see the [Bytecode matching](#bytecode-matching) section for more details
 - jarFileObfuscated: the jar the match was found in appeared to be obfuscated
 - classBytecodePartialMatch: the bytecode of a class file called `JndiManager`, or a class within an obfuscated jar, partially matched the bytecode of a known version, see the [Bytecode partial matching](#bytecode-partial-matching) section for more details
+
+The summary outlines:
+- filesScanned: the total number of files crawled
+- permissionDeniedErrors: the number of directories or files that could not be read due to permissions
+- pathErrors: the number of paths where an unexpected error occurred while trying to identify bad log4j versions
+- pathsSkipped: the numbers of paths skipped from full identification of bad log4j versions due to the config options set
+- numImpactedFiles: the total number of results previously output
 
 Specifying `--summary=false` makes it such that the program does not output a summary line at the end. In this case,
 the program will only print output if vulnerabilities are found.

--- a/changelog/@unreleased/pr-65.v2.yml
+++ b/changelog/@unreleased/pr-65.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Print summary of skipped paths due to config
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/65

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -155,7 +155,7 @@ func Crawl(ctx context.Context, config Config, stdout, stderr io.Writer) (int64,
 			} else {
 				output = color.GreenString("No files affected by %s detected", cveInfo)
 			}
-			output += color.CyanString("\n%d total files scanned, skipped %d paths due to permission denied errors, encountered %d errors processing paths", crawlStats.FilesScanned, crawlStats.PermissionDeniedCount, crawlStats.PathErrorCount)
+			output += color.CyanString("\n%d total files scanned, skipped identifying %d files due to config, skipped %d paths due to permission denied errors, encountered %d errors processing paths", crawlStats.FilesScanned, crawlStats.PathSkippedCount, crawlStats.PermissionDeniedCount, crawlStats.PathErrorCount)
 		}
 		_, _ = fmt.Fprintln(stdout, output)
 	}

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -47,6 +47,8 @@ type Stats struct {
 
 // MatchFunc is used to match a file for processing.
 // If returning a positive finding, a file will be passed onto the ProcessFunc.
+// Returns the finding, if present, along with the version matching as well as the number of
+// files skipped and any error encountered.
 type MatchFunc func(ctx context.Context, path string, d fs.DirEntry) (Finding, Versions, uint64, error)
 
 // ProcessFunc processes the given matched file.

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -51,10 +51,10 @@ func TestCrawler_Crawl(t *testing.T) {
 				regexp.MustCompile(filepath.Join(root, `foo`)),
 				regexp.MustCompile(filepath.Join(root, `baz`)),
 			},
-		}.Crawl(context.Background(), root, func(ctx context.Context, path string, d fs.DirEntry) (Finding, Versions, error) {
+		}.Crawl(context.Background(), root, func(ctx context.Context, path string, d fs.DirEntry) (Finding, Versions, uint64, error) {
 			matchPathInputs = append(matchPathInputs, path)
 			matchDirEntryInputs = append(matchDirEntryInputs, d.Name())
-			return JarName, nil, nil
+			return JarName, nil, 0, nil
 		}, func(ctx context.Context, path string, d fs.DirEntry, result Finding, version Versions) {
 			processInputs = append(processInputs, path)
 			processDirEntryInputs = append(processDirEntryInputs, d.Name())
@@ -73,9 +73,9 @@ func TestCrawler_Crawl(t *testing.T) {
 		cancel()
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
-		}.Crawl(ctx, t.TempDir(), func(context.Context, string, fs.DirEntry) (Finding, Versions, error) {
+		}.Crawl(ctx, t.TempDir(), func(context.Context, string, fs.DirEntry) (Finding, Versions, uint64, error) {
 			countMatch++
-			return JarName, nil, nil
+			return JarName, nil, 0, nil
 		}, func(context.Context, string, fs.DirEntry, Finding, Versions) {
 			countProcess++
 		})
@@ -91,9 +91,9 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(context.Background(), root,
-			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, error) {
+			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
-				return NothingDetected, nil, errors.New("")
+				return NothingDetected, nil, 0, errors.New("")
 			}, func(context.Context, string, fs.DirEntry, Finding, Versions) {
 				countProcess++
 			})
@@ -109,9 +109,9 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(context.Background(), root,
-			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, error) {
+			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
-				return NothingDetected, nil, nil
+				return NothingDetected, nil, 0, nil
 			}, func(context.Context, string, fs.DirEntry, Finding, Versions) {
 				countProcess++
 			})
@@ -127,8 +127,8 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(ctx, root,
-			func(context.Context, string, fs.DirEntry) (Finding, Versions, error) {
-				return JarName, nil, nil
+			func(context.Context, string, fs.DirEntry) (Finding, Versions, uint64, error) {
+				return JarName, nil, 0, nil
 			}, func(innerCtx context.Context, path string, entry fs.DirEntry, result Finding, version Versions) {
 				processInputs = append(processInputs, path)
 				assert.Equal(t, ctx, innerCtx)

--- a/pkg/crawl/identify.go
+++ b/pkg/crawl/identify.go
@@ -209,7 +209,7 @@ func (i *Log4jIdentifier) findArchiveVulnerabilities(ctx context.Context, depth 
 func (i *Log4jIdentifier) vulnerabilityFileWalkFunc(depth uint, result *Finding, versions Versions, obfuscated bool) archive.FileWalkFn {
 	return func(ctx context.Context, path string, size int64, contents io.Reader) (proceed bool, err error) {
 		archiveType, ok := i.ParseArchiveFormat(path)
-		if ok && depth < i.ArchiveMaxDepth {
+		if ok && depth < i.ArchiveMaxDepth && size < i.ArchiveMaxSize {
 			getWalker, maxSize, ok := i.ArchiveWalkers(archiveType)
 			if !ok {
 				return false, fmt.Errorf("archive format unsupported: %d", archiveType)
@@ -237,6 +237,8 @@ func (i *Log4jIdentifier) vulnerabilityFileWalkFunc(depth uint, result *Finding,
 					versions[vv] = struct{}{}
 				}
 			}
+		} else if ok && size >= i.ArchiveMaxSize {
+			i.printInfoFinding("Skipping nested archive above configured maximum size at %s", path)
 		}
 		finding, versionInFile, versionMatch := i.lookForMatchInFileInZip(path, size, contents, obfuscated)
 		if finding == NothingDetected {

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -162,7 +162,7 @@ func TestLog4jIdentifier(t *testing.T) {
 				return nil, -1, false
 			},
 		}
-		_, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
+		_, _, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
 		// Archive types are currently rendered as int, as this is the underlying type of FormatType.
 		// This error should only occur from a regression, so we needn't be too fussed about it right not.
 		require.EqualError(t, err, "archive type unsupported: 0")

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -59,7 +59,7 @@ func TestLog4jIdentifier(t *testing.T) {
 			ArchiveWalkTimeout: time.Millisecond,
 			Limiter:            ratelimit.NewUnlimited(),
 		}
-		_, _, err := identifier.Identify(context.Background(), "foo", stubDirEntry{
+		_, _, _, err := identifier.Identify(context.Background(), "foo", stubDirEntry{
 			name: "bar",
 		})
 		assert.Error(t, err)
@@ -80,7 +80,7 @@ func TestLog4jIdentifier(t *testing.T) {
 			Limiter:            ratelimit.NewUnlimited(),
 			OpenFile:           func(s string) (*os.File, error) { return nil, nil },
 		}
-		_, _, err := identifier.Identify(context.Background(), "foo", stubDirEntry{
+		_, _, _, err := identifier.Identify(context.Background(), "foo", stubDirEntry{
 			name: "sdlkfjsldkjfs.tar.gz",
 		})
 		assert.Equal(t, expectedErr, err)
@@ -114,7 +114,7 @@ func TestLog4jIdentifier(t *testing.T) {
 			OpenFile:           tempEmptyFile(t),
 		}
 
-		_, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
+		_, _, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
 		require.NoError(t, err)
 		assert.Equal(t, 1, fileWalkCalls)
 		assert.Equal(t, 0, readerWalkCalls)
@@ -149,7 +149,7 @@ func TestLog4jIdentifier(t *testing.T) {
 			OpenFile:           tempEmptyFile(t),
 		}
 
-		_, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
+		_, _, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
 		require.NoError(t, err)
 		assert.Equal(t, 1, fileWalkCalls)
 		assert.Equal(t, 3, readerWalkCalls)
@@ -220,7 +220,7 @@ func TestIdentifyFromFileName(t *testing.T) {
 				ParseArchiveFormat: func(s string) (archive.FormatType, bool) { return 0, false },
 			}
 
-			result, version, err := identifier.Identify(context.Background(), "/path/on/disk", stubDirEntry{
+			result, version, _, err := identifier.Identify(context.Background(), "/path/on/disk", stubDirEntry{
 				name: tc.in,
 			})
 			require.NoError(t, err)
@@ -331,7 +331,7 @@ func TestIdentifyFromArchiveContents(t *testing.T) {
 				ArchiveWalkTimeout: time.Second,
 				Limiter:            ratelimit.NewUnlimited(),
 			}
-			result, version, err := identifier.Identify(context.Background(), "/path/on/disk/", stubDirEntry{
+			result, version, _, err := identifier.Identify(context.Background(), "/path/on/disk/", stubDirEntry{
 				name: tc.filename,
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
With https://github.com/palantir/log4j-sniffer/pull/64 there is no longer the signal of the tool exiting that the config caused a file to not be fully examined.

This adds output detailing how many paths were skipped.