### PR TITLE
Check for archive support before comparing size

### DIFF
--- a/pkg/crawl/identify.go
+++ b/pkg/crawl/identify.go
@@ -211,13 +211,13 @@ func (i *Log4jIdentifier) vulnerabilityFileWalkFunc(depth uint, result *Finding,
 		archiveType, ok := i.ParseArchiveFormat(path)
 		if ok && depth < i.ArchiveMaxDepth {
 			getWalker, maxSize, ok := i.ArchiveWalkers(archiveType)
+			if !ok {
+				return false, fmt.Errorf("archive format unsupported: %d", archiveType)
+			}
+
 			if maxSize > -1 && size >= maxSize {
 				i.printInfoFinding("Skipping nested archive above configured maximum size at %s", path)
 			} else {
-				if !ok {
-					return false, fmt.Errorf("archive format unsupported: %d", archiveType)
-				}
-
 				walker, close, archiveErr := getWalker.FromReader(contents)
 				if archiveErr != nil {
 					return false, archiveErr

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -154,6 +154,19 @@ func TestLog4jIdentifier(t *testing.T) {
 		assert.Equal(t, 1, fileWalkCalls)
 		assert.Equal(t, 3, readerWalkCalls)
 	})
+
+	t.Run("reports unsupported archive types", func(t *testing.T) {
+		identifier := crawl.Log4jIdentifier{
+			ParseArchiveFormat: func(s string) (archive.FormatType, bool) { return 0, true },
+			ArchiveWalkers: func(formatType archive.FormatType) (archive.WalkerProvider, int64, bool) {
+				return nil, -1, false
+			},
+		}
+		_, _, err := identifier.Identify(context.Background(), "ignored", stubDirEntry{name: ".zip"})
+		// Archive types are currently rendered as int, as this is the underlying type of FormatType.
+		// This error should only occur from a regression, so we needn't be too fussed about it right not.
+		require.EqualError(t, err, "archive type unsupported: 0")
+	})
 }
 
 func TestIdentifyFromFileName(t *testing.T) {


### PR DESCRIPTION
Prior to this change, if an unsupported archive type was encountered, an error would not be surfaced.
This would only be possible if a regression was not caught during development, but would be a silent error and difficult to catch in the wild.

I'll eventually FLUP with a refactor that will get rid of the need for this but wanted to get this small fix in whilst it's still fresh.