### PR TITLE
Correctly use exact match signatures in partial matching

### DIFF
--- a/changelog/@unreleased/pr-74.v2.yml
+++ b/changelog/@unreleased/pr-74.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Correctly use exact match signatures in partial matching to avoid false
+    positives based on not enough bytecode being matched.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/74

--- a/pkg/crawl/signatures.go
+++ b/pkg/crawl/signatures.go
@@ -356,7 +356,8 @@ func BytecodeMatchesPartialSignatures(methodBytecodes [][]byte) (string, bool) {
 			}
 		}
 		for _, version := range exactMatch.Versions {
-			exactVersionMatched[version] = matchIndex != -1
+			currentValue, present := exactVersionMatched[version]
+			exactVersionMatched[version] = (!present || currentValue) && matchIndex != -1
 		}
 		if matchIndex != -1 {
 			matchedIndexes[matchIndex] = true


### PR DESCRIPTION
Before: potential false positives due to only using one of the exact matches requires for partial matching.
After: all exact matches required must be present for a partial match.