### PR TITLE
Evalaute obfuscation for each class individually rather than averaging a whole jar

### DIFF
--- a/changelog/@unreleased/pr-83.v2.yml
+++ b/changelog/@unreleased/pr-83.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Evalaute obfuscation for each class individually rather than averaging
+    a whole jar
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/83

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -39,8 +39,8 @@ func crawlCmd() *cobra.Command {
 		directoriesCrawledPerSecond        int
 		archivesCrawledPerSecond           int
 		enableObfuscationDetection         bool
-		obfuscatedClassNameAverageLength   uint32
-		obfuscatedPackageNameAverageLength uint32
+		obfuscatedClassNameAverageLength   int
+		obfuscatedPackageNameAverageLength int
 		enablePartialMatchingOnAllClasses  bool
 		enableTraceLogging                 bool
 		disableDetailedFindings            bool
@@ -178,8 +178,8 @@ A max depth of 0 will open up an archive on the filesystem but not any nested ar
 	cmd.Flags().IntVar(&archivesCrawledPerSecond, "archives-per-second-rate-limit", 0, `The maximum number of archives to scan per second. 0 for unlimited.`)
 	cmd.Flags().BoolVar(&enableObfuscationDetection, "enable-obfuscation-detection", true, `Enable applying partial bytecode matching to Jars that appear to be obfuscated.`)
 	cmd.Flags().BoolVar(&enablePartialMatchingOnAllClasses, "enable-partial-matching-on-all-classes", false, `Enable partial bytecode matching to all class files found.`)
-	cmd.Flags().Uint32Var(&obfuscatedClassNameAverageLength, "maximum-average-obfuscated-class-name-length", 3, `The maximum average class name length for classes within a Jar to be considered obfuscated.`)
-	cmd.Flags().Uint32Var(&obfuscatedPackageNameAverageLength, "maximum-average-obfuscated-package-name-length", 3, `The maximum average package name length for packages within a Jar to be considered obfuscated.`)
+	cmd.Flags().IntVar(&obfuscatedClassNameAverageLength, "maximum-average-obfuscated-class-name-length", 3, `The maximum class name length for a class to be considered obfuscated.`)
+	cmd.Flags().IntVar(&obfuscatedPackageNameAverageLength, "maximum-average-obfuscated-package-name-length", 3, `The maximum average package name length a class to be considered obfuscated.`)
 	cmd.Flags().BoolVar(&enableTraceLogging, "enable-trace-logging", false, `Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect`)
 	cmd.Flags().BoolVar(&disableDetailedFindings, "disable-detailed-findings", false, "Do not print out detailed finding information when not outputting in JSON.")
 	cmd.Flags().BoolVar(&disableFlaggingJndiLookup, "disable-flagging-jndi-lookup", false, `Do not report results that only match on the presence of a JndiLookup class.

--- a/integration_test/crawl_integration_test.go
+++ b/integration_test/crawl_integration_test.go
@@ -159,7 +159,7 @@ func TestSummaryContainsExpectedFields(t *testing.T) {
 	cli, err := products.Bin("log4j-sniffer")
 	require.NoError(t, err)
 
-	cmd := exec.Command(cli, "crawl", "../examples", "--summary", "--json")
+	cmd := exec.Command(cli, "crawl", "../examples", "--ignore-dir", "java_projects/", "--summary", "--json")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "command %v failed with output:\n%s", cmd.Args, string(output))
 	lines := strings.Split(string(output), "\n")
@@ -167,7 +167,7 @@ func TestSummaryContainsExpectedFields(t *testing.T) {
 	var summary map[string]int
 	require.NoError(t, json.Unmarshal([]byte(summaryLine), &summary))
 	assert.Equal(t, map[string]int{
-		"filesScanned":           46,
+		"filesScanned":           36,
 		"permissionDeniedErrors": 0,
 		"pathErrors":             0,
 		"numImpactedFiles":       28,

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -42,9 +42,9 @@ type Config struct {
 	// Maximum number of archives to scan per second, or 0 for no limit.
 	ArchivesCrawledPerSecond int
 	// The maximum average class name length for a jar to be considered obfuscated.
-	ObfuscatedClassNameAverageLength uint32
+	ObfuscatedClassNameAverageLength int
 	// The maximum average package name length for a jar to be considered obfuscated.
-	ObfuscatedPackageNameAverageLength uint32
+	ObfuscatedPackageNameAverageLength int
 	// If true, print out detailed information on each finding as it is found
 	PrintDetailedOutput bool
 	// Ignores specifies the regular expressions used to determine which directories to omit.
@@ -67,8 +67,8 @@ func Crawl(ctx context.Context, config Config, process crawl.ProcessFunc, stdout
 		EnableTraceLogging:                 config.EnableTraceLogging,
 		DetailedOutputWriter:               outputWriter,
 		IdentifyObfuscation:                config.ObfuscatedClassNameAverageLength > 0 && config.ObfuscatedPackageNameAverageLength > 0,
-		ObfuscatedClassNameAverageLength:   float32(config.ObfuscatedClassNameAverageLength),
-		ObfuscatedPackageNameAverageLength: float32(config.ObfuscatedPackageNameAverageLength),
+		ObfuscatedClassNameAverageLength:   config.ObfuscatedClassNameAverageLength,
+		ObfuscatedPackageNameAverageLength: config.ObfuscatedPackageNameAverageLength,
 		Limiter:                            limiterFromConfig(config.ArchivesCrawledPerSecond),
 		ArchiveWalkTimeout:                 config.ArchiveListTimeout,
 		ArchiveMaxDepth:                    config.ArchiveMaxDepth,

--- a/internal/crawler/crawl_test.go
+++ b/internal/crawler/crawl_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -250,6 +251,7 @@ func TestCrawlExamplesFindings(t *testing.T) {
 
 	summary, err := Crawl(context.Background(), Config{
 		Root:                               examplesDir,
+		Ignores:                            []*regexp.Regexp{regexp.MustCompile("java_projects/")},
 		ArchiveMaxDepth:                    5,
 		ArchiveMaxSize:                     1024 * 1024 * 10,
 		ObfuscatedClassNameAverageLength:   3,
@@ -264,7 +266,7 @@ func TestCrawlExamplesFindings(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, crawl.Stats{
-		FilesScanned: 46,
+		FilesScanned: 36,
 	}, summary)
 
 	var foundPaths []string


### PR DESCRIPTION
Before: in the case of a jar with mostly non-obfuscated classes with a small number of obfuscated mixed in we'd not examine any class files a the average package and class name length would be skewed by the non-obfuscated classes
After: we consider each class individually as to whether it is obfuscated based on the packages and class name of that class only.

This has the huge benefit of eliminating the initial iteration through all jar filenames, which is expensive in terms of IO and currently memory.