### PR TITLE
Building the gradle project in examples/java_projects results in more…

### DIFF
--- a/integration_test/crawl_integration_test.go
+++ b/integration_test/crawl_integration_test.go
@@ -159,7 +159,7 @@ func TestSummaryContainsExpectedFields(t *testing.T) {
 	cli, err := products.Bin("log4j-sniffer")
 	require.NoError(t, err)
 
-	cmd := exec.Command(cli, "crawl", "../examples", "--summary", "--json")
+	cmd := exec.Command(cli, "crawl", "../examples", "--ignore-dir", "java_projects/", "--summary", "--json")
 	output, err := cmd.CombinedOutput()
 	require.NoError(t, err, "command %v failed with output:\n%s", cmd.Args, string(output))
 	lines := strings.Split(string(output), "\n")
@@ -167,7 +167,7 @@ func TestSummaryContainsExpectedFields(t *testing.T) {
 	var summary map[string]int
 	require.NoError(t, json.Unmarshal([]byte(summaryLine), &summary))
 	assert.Equal(t, map[string]int{
-		"filesScanned":           46,
+		"filesScanned":           36,
 		"permissionDeniedErrors": 0,
 		"pathErrors":             0,
 		"numImpactedFiles":       28,

--- a/internal/crawler/crawl_test.go
+++ b/internal/crawler/crawl_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"io"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -250,6 +251,7 @@ func TestCrawlExamplesFindings(t *testing.T) {
 
 	summary, err := Crawl(context.Background(), Config{
 		Root:                               examplesDir,
+		Ignores:                            []*regexp.Regexp{regexp.MustCompile("java_projects/")},
 		ArchiveMaxDepth:                    5,
 		ArchiveMaxSize:                     1024 * 1024 * 10,
 		ObfuscatedClassNameAverageLength:   3,
@@ -264,7 +266,7 @@ func TestCrawlExamplesFindings(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, crawl.Stats{
-		FilesScanned: 46,
+		FilesScanned: 36,
 	}, summary)
 
 	var foundPaths []string


### PR DESCRIPTION
… files on disk, which breaks the tests.