### PR TITLE
Use a bounded amount of memory per directory

### DIFF
--- a/changelog/@unreleased/pr-88.v2.yml
+++ b/changelog/@unreleased/pr-88.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Use a bounded amount of memory per directory, regardless of how many
+    entries it contains
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/88

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -75,9 +75,10 @@ func Crawl(ctx context.Context, config Config, process crawl.ProcessFunc, stdout
 		ArchiveWalkers:                     archive.Walkers(int64(config.ArchiveMaxSize), config.ArchiveOpenMode),
 	}
 	crawler := crawl.Crawler{
-		Limiter:     limiterFromConfig(config.DirectoriesCrawledPerSecond),
-		ErrorWriter: stderr,
-		IgnoreDirs:  config.Ignores,
+		Limiter:                     limiterFromConfig(config.DirectoriesCrawledPerSecond),
+		ErrorWriter:                 stderr,
+		IgnoreDirs:                  config.Ignores,
+		DirectoryEntriesPerListCall: 100,
 	}
 
 	crawlStats, err := crawler.Crawl(ctx, config.Root, identifier.Identify, process)

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -71,8 +71,13 @@ func (c Crawler) Crawl(ctx context.Context, root string, match MatchFunc, proces
 	return stats, err
 }
 
-func (c Crawler) processDir(ctx context.Context, stats *Stats, path string, match MatchFunc, process ProcessFunc) error {
+func (c Crawler) processDir(ctx context.Context, stats *Stats, path string, match MatchFunc, process ProcessFunc) (err error) {
 	dirInfo, err := os.Open(path)
+	defer func() {
+		if cErr := dirInfo.close(); err == nil && cErr != nil {
+			err = cErr
+		}
+	}()
 	switch {
 	case os.IsPermission(err):
 		stats.PermissionDeniedCount++

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -95,7 +95,7 @@ func (c Crawler) processDir(ctx context.Context, stats *Stats, path string, matc
 			default:
 			}
 
-			nestedPath := strings.Join([]string{path, entry.Name()}, string(os.PathSeparator))
+			nestedPath := filepath.Join(path, entry.Name())
 			if entry.IsDir() {
 				if !c.includeDir(nestedPath) {
 					continue

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -63,10 +63,10 @@ func (c Crawler) Crawl(ctx context.Context, root string, match MatchFunc, proces
 	if err != nil {
 		return stats, err
 	}
-	if !rootFile.IsDir() {
-		err = c.processFile(ctx, &stats, root, rootFile.Name(), match, process)
-	} else {
+	if rootFile.IsDir() {
 		err = c.processDir(ctx, &stats, root, match, process)
+	} else {
+		err = c.processFile(ctx, &stats, root, rootFile.Name(), match, process)
 	}
 	return stats, err
 }

--- a/pkg/crawl/crawler.go
+++ b/pkg/crawl/crawler.go
@@ -18,10 +18,9 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
-	"path/filepath"
 	"regexp"
+	"strings"
 
 	"go.uber.org/ratelimit"
 )
@@ -49,7 +48,7 @@ type Stats struct {
 // If returning a positive finding, a file will be passed onto the ProcessFunc.
 // Returns the finding, if present, along with the version matching as well as the number of
 // files skipped and any error encountered.
-type MatchFunc func(ctx context.Context, path string, d fs.DirEntry) (Finding, Versions, uint64, error)
+type MatchFunc func(ctx context.Context, path, filename string) (Finding, Versions, uint64, error)
 
 // ProcessFunc processes the given matched file.
 type ProcessFunc func(ctx context.Context, path string, result Finding, version Versions)
@@ -60,55 +59,87 @@ type ProcessFunc func(ctx context.Context, path string, result Finding, version 
 // the directory) will be ignored.
 func (c Crawler) Crawl(ctx context.Context, root string, match MatchFunc, process ProcessFunc) (Stats, error) {
 	stats := Stats{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			switch {
-			case os.IsPermission(err):
-				stats.PermissionDeniedCount++
-				return nil
-			case os.IsNotExist(err):
-				// Root should always exist, to pick up on misconfigured service, but log4j-sniffer can encounter transient
-				// files when walking, where WalkDir lists the directory entries but the entry disappears before or
-				// during the walk function iterating over it.
-				if path == root {
+	rootFile, err := os.Lstat(root)
+	if err != nil {
+		return stats, err
+	}
+	if !rootFile.IsDir() {
+		err = c.processFile(ctx, &stats, root, rootFile.Name(), match, process)
+	} else {
+		err = c.processDir(ctx, &stats, root, match, process)
+	}
+	return stats, err
+}
+
+func (c Crawler) processDir(ctx context.Context, stats *Stats, path string, match MatchFunc, process ProcessFunc) error {
+	dirInfo, err := os.Open(path)
+	switch {
+	case os.IsPermission(err):
+		stats.PermissionDeniedCount++
+		return nil
+	case os.IsNotExist(err):
+		return nil
+	case err != nil:
+		stats.PathErrorCount++
+		if c.ErrorWriter != nil {
+			_, _ = fmt.Fprintf(c.ErrorWriter, "Error processing path %s: %v\n", path, err)
+		}
+		return err
+	}
+	dirEntries, err := dirInfo.ReadDir(100)
+	for err != io.EOF {
+		for _, entry := range dirEntries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			nestedPath := strings.Join([]string{path, entry.Name()}, string(os.PathSeparator))
+			if entry.IsDir() {
+				if !c.includeDir(nestedPath) {
+					continue
+				}
+				c.Limiter.Take()
+				nestedError := c.processDir(ctx, stats, nestedPath, match, process)
+				if nestedError != nil {
+					return nestedError
+				}
+			} else if !entry.Type().IsRegular() {
+				continue
+			} else {
+				err = c.processFile(ctx, stats, nestedPath, entry.Name(), match, process)
+				if err != nil {
 					return err
 				}
-				return nil
 			}
-			return err
 		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		if d.IsDir() {
-			if c.includeDir(path) {
-				c.Limiter.Take()
-				return nil
-			}
-			return fs.SkipDir
-		}
-		if !d.Type().IsRegular() {
-			return nil
-		}
-		stats.FilesScanned++
-		matched, version, skipCount, err := match(ctx, path, d)
-		stats.PathSkippedCount += skipCount
-		if err != nil {
+
+		dirEntries, err = dirInfo.ReadDir(100)
+		if err != nil && err != io.EOF {
 			stats.PathErrorCount++
-			if c.ErrorWriter != nil {
-				_, _ = fmt.Fprintf(c.ErrorWriter, "Error processing path %s: %v\n", path, err)
-			}
 			return nil
 		}
-		if matched == NothingDetected {
-			return nil
+	}
+	return nil
+}
+
+func (c Crawler) processFile(ctx context.Context, stats *Stats, path, name string, match MatchFunc, process ProcessFunc) error {
+	stats.FilesScanned++
+	matched, version, skipCount, err := match(ctx, path, name)
+	stats.PathSkippedCount += skipCount
+	if err != nil {
+		stats.PathErrorCount++
+		if c.ErrorWriter != nil {
+			_, _ = fmt.Fprintf(c.ErrorWriter, "Error processing path %s: %v\n", path, err)
 		}
-		process(ctx, path, matched, version)
-		return err
-	})
-	return stats, err
+		return nil
+	}
+	if matched == NothingDetected {
+		return nil
+	}
+	process(ctx, path, matched, version)
+	return err
 }
 
 func (c Crawler) includeDir(path string) bool {

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -17,10 +17,10 @@ package crawl
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,9 +50,9 @@ func TestCrawler_Crawl(t *testing.T) {
 				regexp.MustCompile(filepath.Join(root, `foo`)),
 				regexp.MustCompile(filepath.Join(root, `baz`)),
 			},
-		}.Crawl(context.Background(), root, func(ctx context.Context, path string, d fs.DirEntry) (Finding, Versions, uint64, error) {
+		}.Crawl(context.Background(), root, func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 			matchPathInputs = append(matchPathInputs, path)
-			matchDirEntryInputs = append(matchDirEntryInputs, d.Name())
+			matchDirEntryInputs = append(matchDirEntryInputs, name)
 			return JarName, nil, 0, nil
 		}, func(ctx context.Context, path string, result Finding, version Versions) {
 			processInputs = append(processInputs, path)
@@ -68,9 +68,10 @@ func TestCrawler_Crawl(t *testing.T) {
 		var countProcess int
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
+		root := makeTestFS(t, nil, []string{"foo"})
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
-		}.Crawl(ctx, t.TempDir(), func(context.Context, string, fs.DirEntry) (Finding, Versions, uint64, error) {
+		}.Crawl(ctx, root, func(context.Context, string, string) (Finding, Versions, uint64, error) {
 			countMatch++
 			return JarName, nil, 0, nil
 		}, func(context.Context, string, Finding, Versions) {
@@ -88,7 +89,7 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(context.Background(), root,
-			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, uint64, error) {
+			func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
 				return NothingDetected, nil, 0, errors.New("")
 			}, func(context.Context, string, Finding, Versions) {
@@ -106,7 +107,7 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(context.Background(), root,
-			func(ctx context.Context, path string, entry fs.DirEntry) (Finding, Versions, uint64, error) {
+			func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
 				return NothingDetected, nil, 0, nil
 			}, func(context.Context, string, Finding, Versions) {
@@ -124,13 +125,14 @@ func TestCrawler_Crawl(t *testing.T) {
 		_, err := Crawler{
 			Limiter: ratelimit.NewUnlimited(),
 		}.Crawl(ctx, root,
-			func(context.Context, string, fs.DirEntry) (Finding, Versions, uint64, error) {
+			func(context.Context, string, string) (Finding, Versions, uint64, error) {
 				return JarName, nil, 0, nil
 			}, func(innerCtx context.Context, path string, result Finding, version Versions) {
 				processInputs = append(processInputs, path)
 				assert.Equal(t, ctx, innerCtx)
 			})
 		require.NoError(t, err)
+		sort.Strings(processInputs)
 		assert.Equal(t, []string{
 			filepath.Join(root, "bar"),
 			filepath.Join(root, "foo"),

--- a/pkg/crawl/crawler_test.go
+++ b/pkg/crawl/crawler_test.go
@@ -50,6 +50,7 @@ func TestCrawler_Crawl(t *testing.T) {
 				regexp.MustCompile(filepath.Join(root, `foo`)),
 				regexp.MustCompile(filepath.Join(root, `baz`)),
 			},
+			DirectoryEntriesPerListCall: 1,
 		}.Crawl(context.Background(), root, func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 			matchPathInputs = append(matchPathInputs, path)
 			matchDirEntryInputs = append(matchDirEntryInputs, name)
@@ -70,7 +71,8 @@ func TestCrawler_Crawl(t *testing.T) {
 		cancel()
 		root := makeTestFS(t, nil, []string{"foo"})
 		_, err := Crawler{
-			Limiter: ratelimit.NewUnlimited(),
+			Limiter:                     ratelimit.NewUnlimited(),
+			DirectoryEntriesPerListCall: 1,
 		}.Crawl(ctx, root, func(context.Context, string, string) (Finding, Versions, uint64, error) {
 			countMatch++
 			return JarName, nil, 0, nil
@@ -87,7 +89,8 @@ func TestCrawler_Crawl(t *testing.T) {
 		var countProcess int
 		root := makeTestFS(t, nil, []string{"foo"})
 		_, err := Crawler{
-			Limiter: ratelimit.NewUnlimited(),
+			Limiter:                     ratelimit.NewUnlimited(),
+			DirectoryEntriesPerListCall: 1,
 		}.Crawl(context.Background(), root,
 			func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
@@ -105,7 +108,8 @@ func TestCrawler_Crawl(t *testing.T) {
 		var countProcess int
 		root := makeTestFS(t, nil, []string{"foo"})
 		_, err := Crawler{
-			Limiter: ratelimit.NewUnlimited(),
+			Limiter:                     ratelimit.NewUnlimited(),
+			DirectoryEntriesPerListCall: 1,
 		}.Crawl(context.Background(), root,
 			func(ctx context.Context, path, name string) (Finding, Versions, uint64, error) {
 				matchInputs = append(matchInputs, path)
@@ -123,7 +127,8 @@ func TestCrawler_Crawl(t *testing.T) {
 		ctx := context.Background()
 		root := makeTestFS(t, nil, []string{"foo", "bar"})
 		_, err := Crawler{
-			Limiter: ratelimit.NewUnlimited(),
+			Limiter:                     ratelimit.NewUnlimited(),
+			DirectoryEntriesPerListCall: 1,
 		}.Crawl(ctx, root,
 			func(context.Context, string, string) (Finding, Versions, uint64, error) {
 				return JarName, nil, 0, nil

--- a/pkg/crawl/identify.go
+++ b/pkg/crawl/identify.go
@@ -111,7 +111,7 @@ type Log4jIdentifier struct {
 // The function identifies:
 // - vulnerable log4j jar files.
 // - zipped files containing vulnerable log4j files, using the provided ZipFileLister.
-func (i *Log4jIdentifier) Identify(ctx context.Context, path string, d fs.DirEntry) (result Finding, versions Versions, skipped uint64, err error) {
+func (i *Log4jIdentifier) Identify(ctx context.Context, path, filename string) (result Finding, versions Versions, skipped uint64, err error) {
 	i.printTraceMessage("Identifying file %s", path)
 	if i.ArchiveWalkTimeout > 0 {
 		ctxWithTimeout, cancel := context.WithTimeout(ctx, i.ArchiveWalkTimeout)
@@ -121,7 +121,7 @@ func (i *Log4jIdentifier) Identify(ctx context.Context, path string, d fs.DirEnt
 
 	result = NothingDetected
 	versions = make(Versions)
-	lowercaseFilename := strings.ToLower(d.Name())
+	lowercaseFilename := strings.ToLower(filename)
 
 	var log4jMatch bool
 	if strings.HasSuffix(lowercaseFilename, ".jar") {


### PR DESCRIPTION
Before: the entire contents of a directory were read in to memory to ensure the paths were processed in a deterministic order
After: directories are read in batches, bounding the amount of memory used to O(1). Results may appear in different orders depending on what the directory list call returns.