### PR TITLE
Extract crawl flags and logger

### DIFF
--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -17,40 +17,24 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"math"
-	"regexp"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/palantir/log4j-sniffer/internal/crawler"
-	"github.com/palantir/log4j-sniffer/pkg/archive"
 	"github.com/palantir/log4j-sniffer/pkg/crawl"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 func crawlCmd() *cobra.Command {
 	var (
-		ignoreDirs                         []string
-		archiveOpenMode                    string
-		perArchiveTimeout                  time.Duration
-		nestedArchiveMaxDepth              uint
-		nestedArchiveMaxSize               uint
-		directoriesCrawledPerSecond        int
-		archivesCrawledPerSecond           int
-		enableObfuscationDetection         bool
-		obfuscatedClassNameAverageLength   int
-		obfuscatedPackageNameAverageLength int
-		enablePartialMatchingOnAllClasses  bool
-		enableTraceLogging                 bool
-		disableDetailedFindings            bool
-		disableCVE45105                    bool
-		disableCVE44832                    bool
-		disableFlaggingJndiLookup          bool
-		disableUnknownVersions             bool
-		outputJSON                         bool
-		outputFilePathOnly                 bool
-		outputSummary                      bool
+		cmdCrawlFlags             crawlFlags
+		disableDetailedFindings   bool
+		disableCVE45105           bool
+		disableCVE44832           bool
+		disableFlaggingJndiLookup bool
+		disableUnknownVersions    bool
+		outputJSON                bool
+		outputFilePathOnly        bool
+		outputSummary             bool
 	)
 
 	cmd := cobra.Command{
@@ -63,34 +47,8 @@ If a directory is provided, it is traversed and all files are scanned.
 Use the ignore-dir flag to provide directories of which to ignore all nested files.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var ignores []*regexp.Regexp
-			for _, pattern := range ignoreDirs {
-				compiled, err := regexp.Compile(pattern)
-				if err != nil {
-					return errors.Wrapf(err, "failed to compile ignore-dir pattern %q", pattern)
-				}
-				ignores = append(ignores, compiled)
-			}
-
-			if !enableObfuscationDetection {
-				obfuscatedClassNameAverageLength, obfuscatedPackageNameAverageLength = 0, 0
-			}
-			if enablePartialMatchingOnAllClasses {
-				obfuscatedClassNameAverageLength, obfuscatedPackageNameAverageLength = math.MaxInt32, math.MaxInt32
-			}
-
 			if outputJSON && outputFilePathOnly {
 				return fmt.Errorf("--file-path-only cannot be used with --json")
-			}
-
-			var mode archive.FileOpenMode
-			switch archiveOpenMode {
-			case "standard":
-				mode = archive.StandardOpen
-			case "directio":
-				mode = archive.DirectIOOpen
-			default:
-				return fmt.Errorf(`unsupported --archive-open-mode: %s. Supported values are "standard" and "directio"`, archiveOpenMode)
 			}
 
 			reporter := crawl.Reporter{
@@ -103,20 +61,14 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 				DisableFlaggingUnknownVersions: disableUnknownVersions,
 			}
 
-			crawlSum, err := crawler.Crawl(cmd.Context(), crawler.Config{
-				Root:                               args[0],
-				ArchiveOpenMode:                    mode,
-				ArchiveListTimeout:                 perArchiveTimeout,
-				ArchiveMaxDepth:                    nestedArchiveMaxDepth,
-				ArchiveMaxSize:                     nestedArchiveMaxSize,
-				DirectoriesCrawledPerSecond:        directoriesCrawledPerSecond,
-				ArchivesCrawledPerSecond:           archivesCrawledPerSecond,
-				ObfuscatedClassNameAverageLength:   obfuscatedClassNameAverageLength,
-				ObfuscatedPackageNameAverageLength: obfuscatedPackageNameAverageLength,
-				PrintDetailedOutput:                !disableDetailedFindings && !outputJSON && !outputFilePathOnly,
-				EnableTraceLogging:                 enableTraceLogging,
-				Ignores:                            ignores,
-			}, reporter.Report, cmd.OutOrStdout(), cmd.OutOrStderr())
+			crawlConfig, err := createCrawlConfig(args[0], cmdCrawlFlags)
+			if err != nil {
+				return err
+			}
+			// only enable printing details if already enabled and we're not in json or file-only mode
+			crawlConfig.PrintDetailedOutput = crawlConfig.PrintDetailedOutput && !outputJSON && !outputFilePathOnly
+
+			crawlSum, err := crawler.Crawl(cmd.Context(), crawlConfig, reporter.Report, cmd.OutOrStdout(), cmd.OutOrStderr())
 			if err != nil {
 				return err
 			}
@@ -160,29 +112,8 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 			return err
 		},
 	}
-	cmd.Flags().StringSliceVar(&ignoreDirs, "ignore-dir", nil, `Specify directory pattern to ignore. Use multiple times to supply multiple patterns.
-Patterns should be relative to the provided root.
-e.g. ignore "^/proc" to ignore "/proc" when using a crawl root of "/"`)
-	cmd.Flags().StringVar(&archiveOpenMode, "archive-open-mode", "standard", `Supported values:
-  standard - standard file opening will be used. This may cause the filesystem cache to be populated with reads from the archive opens.
-  directio - direct I/O will be used when opening archives that require sequential reading of their content without being able to skip to file tables at known locations within the file.
-             For example, "directio" can have an effect on the way that tar-based archives are read but will have no effect on zip-based archives.
-             Using "directio" will cause the filesystem cache to be skipped where possible. "directio" is not supported on tmpfs filesystems and will cause tmpfs archive files to report an error.`)
-	cmd.Flags().DurationVar(&perArchiveTimeout, "per-archive-timeout", 15*time.Minute, `If this duration is exceeded when inspecting an archive, 
-an error will be logged and the crawler will move onto the next file.`)
-	cmd.Flags().UintVar(&nestedArchiveMaxSize, "nested-archive-max-size", 5*1024*1024, `The maximum compressed size in bytes of any nested archive that will be unarchived for inspection.
-This limit is made a per-depth level.
-The overall limit to nested archive size unarchived should be controlled 
-by both the nested-archive-max-size and nested-archive-max-depth.`)
-	cmd.Flags().UintVar(&nestedArchiveMaxDepth, "nested-archive-max-depth", 0, `The maximum depth to recurse into nested archives. 
-A max depth of 0 will open up an archive on the filesystem but not any nested archives.`)
-	cmd.Flags().IntVar(&directoriesCrawledPerSecond, "directories-per-second-rate-limit", 0, `The maximum number of directories to crawl per second. 0 for unlimited.`)
-	cmd.Flags().IntVar(&archivesCrawledPerSecond, "archives-per-second-rate-limit", 0, `The maximum number of archives to scan per second. 0 for unlimited.`)
-	cmd.Flags().BoolVar(&enableObfuscationDetection, "enable-obfuscation-detection", true, `Enable applying partial bytecode matching to Jars that appear to be obfuscated.`)
-	cmd.Flags().BoolVar(&enablePartialMatchingOnAllClasses, "enable-partial-matching-on-all-classes", false, `Enable partial bytecode matching to all class files found.`)
-	cmd.Flags().IntVar(&obfuscatedClassNameAverageLength, "maximum-average-obfuscated-class-name-length", 3, `The maximum class name length for a class to be considered obfuscated.`)
-	cmd.Flags().IntVar(&obfuscatedPackageNameAverageLength, "maximum-average-obfuscated-package-name-length", 3, `The maximum average package name length a class to be considered obfuscated.`)
-	cmd.Flags().BoolVar(&enableTraceLogging, "enable-trace-logging", false, `Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect`)
+
+	applyCrawlFlags(&cmd, &cmdCrawlFlags)
 	cmd.Flags().BoolVar(&disableDetailedFindings, "disable-detailed-findings", false, "Do not print out detailed finding information when not outputting in JSON.")
 	cmd.Flags().BoolVar(&disableFlaggingJndiLookup, "disable-flagging-jndi-lookup", false, `Do not report results that only match on the presence of a JndiLookup class.
 Even when disabled results which match other criteria will still report the presence of JndiLookup if relevant.`)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+
+	"github.com/palantir/log4j-sniffer/internal/crawler"
+	"github.com/palantir/log4j-sniffer/pkg/archive"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type crawlFlags struct {
+	ignoreDirs                         []string
+	archiveOpenMode                    string
+	perArchiveTimeout                  time.Duration
+	nestedArchiveMaxDepth              uint
+	nestedArchiveMaxSize               uint
+	directoriesCrawledPerSecond        int
+	archivesCrawledPerSecond           int
+	enableObfuscationDetection         bool
+	obfuscatedClassNameAverageLength   int
+	obfuscatedPackageNameAverageLength int
+	enablePartialMatchingOnAllClasses  bool
+	enableTraceLogging                 bool
+	disableDetailedFindings            bool
+}
+
+func applyCrawlFlags(cmd *cobra.Command, flags *crawlFlags) {
+	cmd.Flags().StringSliceVar(&flags.ignoreDirs, "ignore-dir", nil, `Specify directory pattern to ignore. Use multiple times to supply multiple patterns.
+Patterns should be relative to the provided root.
+e.g. ignore "^/proc" to ignore "/proc" when using a crawl root of "/"`)
+	cmd.Flags().StringVar(&flags.archiveOpenMode, "archive-open-mode", "standard", `Supported values:
+  standard - standard file opening will be used. This may cause the filesystem cache to be populated with reads from the archive opens.
+  directio - direct I/O will be used when opening archives that require sequential reading of their content without being able to skip to file tables at known locations within the file.
+             For example, "directio" can have an effect on the way that tar-based archives are read but will have no effect on zip-based archives.
+             Using "directio" will cause the filesystem cache to be skipped where possible. "directio" is not supported on tmpfs filesystems and will cause tmpfs archive files to report an error.`)
+	cmd.Flags().DurationVar(&flags.perArchiveTimeout, "per-archive-timeout", 15*time.Minute, `If this duration is exceeded when inspecting an archive, 
+an error will be logged and the crawler will move onto the next file.`)
+	cmd.Flags().UintVar(&flags.nestedArchiveMaxSize, "nested-archive-max-size", 5*1024*1024, `The maximum compressed size in bytes of any nested archive that will be unarchived for inspection.
+This limit is made a per-depth level.
+The overall limit to nested archive size unarchived should be controlled 
+by both the nested-archive-max-size and nested-archive-max-depth.`)
+	cmd.Flags().UintVar(&flags.nestedArchiveMaxDepth, "nested-archive-max-depth", 0, `The maximum depth to recurse into nested archives. 
+A max depth of 0 will open up an archive on the filesystem but not any nested archives.`)
+	cmd.Flags().IntVar(&flags.directoriesCrawledPerSecond, "directories-per-second-rate-limit", 0, `The maximum number of directories to crawl per second. 0 for unlimited.`)
+	cmd.Flags().IntVar(&flags.archivesCrawledPerSecond, "archives-per-second-rate-limit", 0, `The maximum number of archives to scan per second. 0 for unlimited.`)
+	cmd.Flags().BoolVar(&flags.enableObfuscationDetection, "enable-obfuscation-detection", true, `Enable applying partial bytecode matching to Jars that appear to be obfuscated.`)
+	cmd.Flags().BoolVar(&flags.enablePartialMatchingOnAllClasses, "enable-partial-matching-on-all-classes", false, `Enable partial bytecode matching to all class files found.`)
+	cmd.Flags().IntVar(&flags.obfuscatedClassNameAverageLength, "maximum-average-obfuscated-class-name-length", 3, `The maximum class name length for a class to be considered obfuscated.`)
+	cmd.Flags().IntVar(&flags.obfuscatedPackageNameAverageLength, "maximum-average-obfuscated-package-name-length", 3, `The maximum average package name length a class to be considered obfuscated.`)
+	cmd.Flags().BoolVar(&flags.enableTraceLogging, "enable-trace-logging", false, `Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect`)
+}
+
+func createCrawlConfig(root string, flags crawlFlags) (crawler.Config, error) {
+	ignores, err := flags.resolveIgnoreDirs()
+	if err != nil {
+		return crawler.Config{}, err
+	}
+
+	mode, err := flags.resolveArchiveOpenMode()
+	if err != nil {
+		return crawler.Config{}, err
+	}
+
+	var obfuscatedClassNameAverageLength, obfuscatedPackageNameAverageLength int
+	if flags.enableObfuscationDetection {
+		obfuscatedClassNameAverageLength = flags.obfuscatedClassNameAverageLength
+		obfuscatedPackageNameAverageLength = flags.obfuscatedPackageNameAverageLength
+	}
+	if flags.enablePartialMatchingOnAllClasses {
+		obfuscatedClassNameAverageLength, obfuscatedPackageNameAverageLength = math.MaxInt32, math.MaxInt32
+	}
+
+	return crawler.Config{
+		Root:                               root,
+		ArchiveOpenMode:                    mode,
+		ArchiveListTimeout:                 flags.perArchiveTimeout,
+		ArchiveMaxDepth:                    flags.nestedArchiveMaxDepth,
+		ArchiveMaxSize:                     flags.nestedArchiveMaxSize,
+		DirectoriesCrawledPerSecond:        flags.directoriesCrawledPerSecond,
+		ArchivesCrawledPerSecond:           flags.archivesCrawledPerSecond,
+		ObfuscatedClassNameAverageLength:   obfuscatedClassNameAverageLength,
+		ObfuscatedPackageNameAverageLength: obfuscatedPackageNameAverageLength,
+		PrintDetailedOutput:                !flags.disableDetailedFindings,
+		EnableTraceLogging:                 flags.enableTraceLogging,
+		Ignores:                            ignores,
+	}, nil
+}
+
+func (fs crawlFlags) resolveArchiveOpenMode() (archive.FileOpenMode, error) {
+	switch fs.archiveOpenMode {
+	case "standard":
+		return archive.StandardOpen, nil
+	case "directio":
+		return archive.DirectIOOpen, nil
+	}
+	return archive.StandardOpen, fmt.Errorf(`unsupported --archive-open-mode: %s. Supported values are "standard" and "directio"`, fs.archiveOpenMode)
+}
+
+func (fs crawlFlags) resolveIgnoreDirs() ([]*regexp.Regexp, error) {
+	var ignores []*regexp.Regexp
+	for _, pattern := range fs.ignoreDirs {
+		compiled, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to compile ignore-dir pattern %q", pattern)
+		}
+		ignores = append(ignores, compiled)
+	}
+	return ignores, nil
+}

--- a/internal/crawler/crawl.go
+++ b/internal/crawler/crawl.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/palantir/log4j-sniffer/pkg/archive"
 	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/palantir/log4j-sniffer/pkg/log"
 	"go.uber.org/ratelimit"
 )
 
@@ -63,9 +64,11 @@ func Crawl(ctx context.Context, config Config, process crawl.HandleFindingFunc, 
 		outputWriter = stdout
 	}
 	identifier := crawl.Log4jIdentifier{
-		ErrorWriter:                        stderr,
-		EnableTraceLogging:                 config.EnableTraceLogging,
-		DetailedOutputWriter:               outputWriter,
+		Logger: log.Logger{
+			ErrorWriter:        stderr,
+			EnableTraceLogging: config.EnableTraceLogging,
+			OutputWriter:       outputWriter,
+		},
 		IdentifyObfuscation:                config.ObfuscatedClassNameAverageLength > 0 && config.ObfuscatedPackageNameAverageLength > 0,
 		ObfuscatedClassNameAverageLength:   config.ObfuscatedClassNameAverageLength,
 		ObfuscatedPackageNameAverageLength: config.ObfuscatedPackageNameAverageLength,

--- a/pkg/crawl/path.go
+++ b/pkg/crawl/path.go
@@ -26,6 +26,10 @@ import (
 // represent a file being walked that is nested into two layers of archive.
 type Path []string
 
+func (n Path) String() string {
+	return n.Joined()
+}
+
 // Joined provides a string representation of the given Path, where each layer
 // is separated by a '!'.
 func (n Path) Joined() string {

--- a/pkg/crawl/report.go
+++ b/pkg/crawl/report.go
@@ -248,7 +248,7 @@ func (r *Reporter) Report(ctx context.Context, path Path, result Finding, versio
 		}
 		outputToWrite = path[0]
 	} else {
-		outputToWrite = color.YellowString("[MATCH] "+cveMessage+" in file %s. log4j versions: %s. Reasons: %s", path.Joined(), strings.Join(versions, ", "), strings.Join(readableReasons, ", "))
+		outputToWrite = color.YellowString("[MATCH] "+cveMessage+" in file %s. log4j versions: %s. Reasons: %s", path, strings.Join(versions, ", "), strings.Join(readableReasons, ", "))
 	}
 	_, _ = fmt.Fprintln(r.OutputWriter, outputToWrite)
 }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fatih/color"
+)
+
+type Logger struct {
+	OutputWriter       io.Writer
+	ErrorWriter        io.Writer
+	EnableTraceLogging bool
+}
+
+func (i Logger) Trace(format string, args ...interface{}) {
+	if i.OutputWriter != nil && i.EnableTraceLogging {
+		_, _ = fmt.Fprintln(i.OutputWriter, fmt.Sprintf("[TRACE] "+format, args...))
+	}
+}
+
+func (i Logger) Info(format string, args ...interface{}) {
+	if i.OutputWriter != nil {
+		_, _ = fmt.Fprintln(i.OutputWriter, color.CyanString("[INFO] "+format, args...))
+	}
+}
+
+func (i Logger) Error(format string, args ...interface{}) {
+	if i.ErrorWriter != nil {
+		_, _ = fmt.Fprintln(i.ErrorWriter, color.RedString("[ERROR] "+format, args...))
+	}
+}


### PR DESCRIPTION
The PR to add support for deletion was getting large so I'm creating this PR in advance to avoid creating noise in that PR.

* Extracts crawl flags out into a data structure. This will be used in a follow up PR that contains a command using the same crawl configurations to identify files for deletion.
* Extracts a logger out that will be used within some of the types for deletion also. The logger accepts `interface{}` arguments, in the same vein as the standard `logger` and `fmt` packages.
* `crawl.Path` has had a `String()` method added, deferring to the `Join()` method, that means `Path` values can be directly passed to the logger and will be printed appropriately.
