### PR TITLE
Support deleting findings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,25 @@ all-tags-filter: &all-tags-filter
     tags:
       only: /.*/
 
+jobs:
+  dist:
+    executor: circleci-go
+    steps:
+      - checkout
+      - run: version="$(./godelw project-version)" && for dist in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64; do mkdir -p ./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/$dist; done
+      - run: version="$(./godelw project-version)" && GOFLAGS="-mod=vendor" CGO_ENABLED="1" GOOS=linux   GOARCH=amd64 go build -ldflags "-X github.com/palantir/log4j-sniffer/cmd.Version=$version" -o "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/linux-amd64/log4j-sniffer" .
+      - run: version="$(./godelw project-version)" && GOFLAGS="-mod=vendor"                 GOOS=linux   GOARCH=arm64 go build -ldflags "-X github.com/palantir/log4j-sniffer/cmd.Version=$version" -o "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/linux-arm64/log4j-sniffer" .
+      - run: version="$(./godelw project-version)" && GOFLAGS="-mod=vendor"                 GOOS=darwin  GOARCH=amd64 go build -ldflags "-X github.com/palantir/log4j-sniffer/cmd.Version=$version" -o "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/darwin-amd64/log4j-sniffer" .
+      - run: version="$(./godelw project-version)" && GOFLAGS="-mod=vendor"                 GOOS=darwin  GOARCH=arm64 go build -ldflags "-X github.com/palantir/log4j-sniffer/cmd.Version=$version" -o "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/darwin-arm64/log4j-sniffer" .
+      - run: version="$(./godelw project-version)" && GOFLAGS="-mod=vendor"                 GOOS=windows GOARCH=amd64 go build -ldflags "-X github.com/palantir/log4j-sniffer/cmd.Version=$version" -o "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/windows-amd64/log4j-sniffer.exe" .
+      - run: version="$(./godelw project-version)" && for dist in linux-amd64 linux-arm64 darwin-amd64 darwin-arm64; do tar -C "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/$dist" -zcvf "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version-$dist.tgz" log4j-sniffer; done
+      # windows-amd requires .exe so cannot be included in above loop for tarring
+      - run: version="$(./godelw project-version)" && tar -C "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version/windows-amd64" -zcvf "./out/dist/log4j-sniffer/$version/os-arch-bin/log4j-sniffer-$version-windows-amd64.tgz" log4j-sniffer.exe
+      - save_cache:
+          key: dist-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ .Environment.CIRCLE_SHA1 }}-v1
+          paths:
+            - out
+
 workflows:
   version: 2
   verify-test-dist-publish:
@@ -44,9 +63,6 @@ workflows:
           <<: *homepath
           <<: *gopath
           <<: *all-tags-filter
-      - godel/dist:
+      - dist:
           name: dist
-          executor: circleci-go
-          <<: *homepath
-          <<: *gopath
           <<: *all-tags-filter

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Usage:
 Examples:
 Delete all findings nested beneath /path/to/dir that are owned by foo and contain findings that match both classFileMd5 and jarFileObfuscated.
 
-log4j-sniffer delete /path/to/dir --dry-run=false --directory-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated
+log4j-sniffer delete /path/to/dir --dry-run=false --filepath-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated
 
 Flags:
       --archive-open-mode string                             Supported values:
@@ -356,38 +356,38 @@ Flags:
                                                                           Using "directio" will cause the filesystem cache to be skipped where possible. "directio" is not supported on tmpfs filesystems and will cause tmpfs archive files to report an error. (default "standard")
       --archives-per-second-rate-limit int                   The maximum number of archives to scan per second. 0 for unlimited.
       --directories-per-second-rate-limit int                The maximum number of directories to crawl per second. 0 for unlimited.
-      --filepath-owner strings                         Provide a directory pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
-                                                             Multiple values can be provided and values must be provided in the form directory_pattern:owner_template, where a directory pattern and owner template are colon separated.
-
-                                                             When a file is deemed to be vulnerable, the directory containing the file will be matched against all directory patterns.
-                                                             For all directory matches, the owner template will be expanded against the directory pattern match to resolve to a file owner value that the actual file owner will then be compared against.
-                                                             Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the directory pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
-
-                                                             If no directories match, the file will not be deleted. If any directories match, all matching directory corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.
-
-                                                             Examples:
-                                                             --directory-owner ^/foo/bar:qux would consider /foo/bar/baz for deletion only if it is owned by qux
-                                                             --directory-owner ^/foo/bar/:qux and --directory-owner ^/foo/bar/baz:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match
-                                                             --directory-owner ^/foo/(\w+):$1 would consider /foo/bar/baz for deletion only if it is owned by bar
-
       --dry-run                                              When true, a line with be output instead of deleting a file. Use --dry-run=false to enable deletion. (default true)
       --enable-obfuscation-detection                         Enable applying partial bytecode matching to Jars that appear to be obfuscated. (default true)
       --enable-partial-matching-on-all-classes               Enable partial bytecode matching to all class files found.
       --enable-trace-logging                                 Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect.
+      --filepath-owner strings                               Provide a filepath pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
+                                                             Multiple values can be provided and values must be provided in the form filepath_pattern:owner_template, where a filepath pattern and owner template are colon separated.
+
+                                                             When a file is deemed to be vulnerable, the path of the file containing the vulnerability will be matched against all filepath patterns.
+                                                             For all filepath matches, the owner template will be expanded against the filepath pattern match to resolve to a file owner value that the actual file owner will then be compared against.
+                                                             Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the filepath pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
+
+                                                             If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.
+
+                                                             Examples:
+                                                             --filepath-owner ^/foo/bar/.+:qux would consider /foo/bar/baz for deletion only if it is owned by qux.
+                                                             --filepath-owner ^/foo/bar/.+:qux and --filepath-owner ^/foo/bar/baz/.+:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match.
+                                                             --filepath-owner ^/foo/(\w+)/.*:$1 would consider /foo/bar/baz for deletion only if it is owned by bar.
+
       --finding-match strings                                When supplied, any vulnerable finding must contain all values that are provided to finding-match for it to be considered for deletion.
                                                              These values are considered on a finding-by-finding basis, i.e. an archive containing two separate vulnerable jars will only be deleted if either of the contained jars matches all finding-match values.
 
-                                                             Supported values are as follows:
-                                                             - classBytecodeInstructionMd5
-                                                             - classBytecodePartialMatch
-                                                             - classFileMd5
-                                                             - jarFileObfuscated
-                                                             - jarName
-                                                             - jarNameInsideArchive
-                                                             - jndiLookupClassName
-                                                             - jndiLookupClassPackageAndName
-                                                             - jndiManagerClassName
-                                                             - jndiManagerClassPackageAndName
+                                                             Supported values are as follows, but can be provided case-insensitively:
+                                                             - ClassBytecodeInstructionMd5
+                                                             - ClassBytecodePartialMatch
+                                                             - ClassFileMd5
+                                                             - JarFileObfuscated
+                                                             - JarName
+                                                             - JarNameInsideArchive
+                                                             - JndiLookupClassName
+                                                             - JndiLookupClassPackageAndName
+                                                             - JndiManagerClassName
+                                                             - JndiManagerClassPackageAndName
 
                                                              Example:
                                                              --finding-match classFileMd5 and --finding-match jarFileObfuscated would only delete a file containing a vulnerability if the vulnerability contains a class file hash match and an obfuscated jar name.

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Dry-run mode is enabled by default, where a line will be output to state where a
 It is recommended to run using dry-run mode enabled, checking the logged output and then running with dry-run disabled using the same configuration flags.
 Use --dry-run=false to turn off dry-run mode, enabling deletes.
 
-When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of directory-with-owner.
+When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of filepath-owner.
 
 Usage:
   log4j-sniffer delete <root> [flags]
@@ -356,7 +356,7 @@ Flags:
                                                                           Using "directio" will cause the filesystem cache to be skipped where possible. "directio" is not supported on tmpfs filesystems and will cause tmpfs archive files to report an error. (default "standard")
       --archives-per-second-rate-limit int                   The maximum number of archives to scan per second. 0 for unlimited.
       --directories-per-second-rate-limit int                The maximum number of directories to crawl per second. 0 for unlimited.
-      --directory-with-owner strings                         Provide a directory pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
+      --filepath-owner strings                         Provide a directory pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
                                                              Multiple values can be provided and values must be provided in the form directory_pattern:owner_template, where a directory pattern and owner template are colon separated.
 
                                                              When a file is deemed to be vulnerable, the directory containing the file will be matched against all directory patterns.

--- a/README.md
+++ b/README.md
@@ -369,6 +369,12 @@ Flags:
 
                                                              If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.
 
+                                                             Architecture-specific behaviour:
+                                                             - linux-amd64: libc-backed code is used, which is able to infer the owner of a file over a broad range of account setups.
+                                                             - linux-arm64: only the user running or users from /etc/passwd will be available to infer file ownership.
+                                                             - darwin-*: only the user running or users from /etc/passwd will be available to infer file ownership.
+                                                             - windows-*: file ownership is unsupported and --skip-owner-check should be used instead.
+
                                                              Examples:
                                                              --filepath-owner ^/foo/bar/.+:qux would consider /foo/bar/baz for deletion only if it is owned by qux.
                                                              --filepath-owner ^/foo/bar/.+:qux and --filepath-owner ^/foo/bar/baz/.+:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match.

--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -4,6 +4,7 @@ feature:
     A subcommand, `log4j-sniffer delete`, has been added that crawls the filesystem for vulnerable log4j versions and can delete them based on some configuration supplied by flags.
 
     The flags for tuning configure figure deletion based on file ownership (on unix-like systems) and type of findings found within a file.
+
     Please run `log4j-sniffer delete -h` for detailed documentation.
   links:
   - https://github.com/palantir/log4j-sniffer/pull/93

--- a/changelog/@unreleased/pr-93.v2.yml
+++ b/changelog/@unreleased/pr-93.v2.yml
@@ -1,0 +1,9 @@
+type: feature
+feature:
+  description: |-
+    A subcommand, `log4j-sniffer delete`, has been added that crawls the filesystem for vulnerable log4j versions and can delete them based on some configuration supplied by flags.
+
+    The flags for tuning configure figure deletion based on file ownership (on unix-like systems) and type of findings found within a file.
+    Please run `log4j-sniffer delete -h` for detailed documentation.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/93

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -109,7 +109,7 @@ Examples:
 	cmd.Flags().StringSliceVar(&findingsMatches, "finding-match", nil, `When supplied, any vulnerable finding must contain all values that are provided to finding-match for it to be considered for deletion.
 These values are considered on a finding-by-finding basis, i.e. an archive containing two separate vulnerable jars will only be deleted if either of the contained jars matches all finding-match values.
 
-Supported values are as follows:
+Supported values are as follows, but can be provided case-insensitively:
 `+strings.Join(prefixAll(crawl.SupportedVulnerableFindingValues(), "- "), "\n")+`
 
 Example:

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -97,7 +97,13 @@ When a file is deemed to be vulnerable, the path of the file containing the vuln
 For all filepath matches, the owner template will be expanded against the filepath pattern match to resolve to a file owner value that the actual file owner will then be compared against.
 Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the filepath pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
 
-If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.  
+If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.
+
+Architecture-specific behaviour:
+- linux-amd64: libc-backed code is used, which is able to infer the owner of a file over a broad range of account setups.
+- linux-arm64: only the user running or users from /etc/passwd will be available to infer file ownership.
+- darwin-*: only the user running or users from /etc/passwd will be available to infer file ownership.
+- windows-*: file ownership is unsupported and --skip-owner-check should be used instead.
 
 Examples:
 --filepath-owner ^/foo/bar/.+:qux would consider /foo/bar/baz for deletion only if it is owned by qux.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/palantir/log4j-sniffer/internal/crawler"
+	"github.com/palantir/log4j-sniffer/internal/deleter"
+	snifferos "github.com/palantir/log4j-sniffer/internal/os"
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/palantir/log4j-sniffer/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+func deleteCmd() *cobra.Command {
+	var (
+		cmdCrawlFlags         crawlFlags
+		dryRun                bool
+		skipOwnerCheck        bool
+		directoriesWithOwners []string
+		findingsMatches       []string
+	)
+	cmd := cobra.Command{
+		Use: "delete <root>",
+		Example: `Delete all findings nested beneath /path/to/dir that are owned by foo and contain findings that match both classFileMd5 and jarFileObfuscated.
+
+log4j-sniffer delete /path/to/dir --dry-run=false --directory-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated`,
+		Short: "Delete files containing log4j vulnerabilities",
+		Long: `Delete files containing log4j vulnerabilities.
+
+Crawl the file system from root, detecting files containing log4j-vulnerabilities and deleting them if they meet certain requirements determined by the command flags.
+Root must be provided and can be a single file or directory.
+
+Dry-run mode is enabled by default, where a line will be output to state where a file would be deleted when running not in dry run mode.
+It is recommended to run using dry-run mode enabled, checking the logged output and then running with dry-run disabled using the same configuration flags.
+Use --dry-run=false to turn off dry-run mode, enabling deletes.
+
+When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of directory-with-owner.
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			crawlConfig, err := createCrawlConfig(args[0], cmdCrawlFlags)
+			if err != nil {
+				return err
+			}
+
+			if len(directoriesWithOwners) > 0 && skipOwnerCheck {
+				return errors.New("--directory-with-owner and --skip-owner-check cannot be used together")
+			}
+			if len(directoriesWithOwners) == 0 && !skipOwnerCheck {
+				return errors.New("at least one --directory-with-owner value must be provided or --skip-owner-check must be set")
+			}
+
+			var ms []deleter.Matcher
+			for _, value := range directoriesWithOwners {
+				split := strings.Split(value, ":")
+				if len(split) != 2 {
+					return fmt.Errorf(`invalid directory-with-owner, must contain 2 colon-separated segments but got %q`, value)
+				}
+				expr, err := regexp.Compile(split[0])
+				if err != nil {
+					return fmt.Errorf("error compiling pattern for directory-with-owner %s: %w", value, err)
+				}
+				ms = append(ms, deleter.TemplatedOwner{
+					DirectoryExpression: expr,
+					OwnerTemplate:       split[1],
+				})
+			}
+
+			var minimumFindingsRequirement crawl.Finding
+			for _, value := range findingsMatches {
+				f, err := crawl.FindingOf(value)
+				if err != nil {
+					return err
+				}
+				minimumFindingsRequirement |= f
+			}
+
+			var detailedOutputWriter io.Writer
+			var enableTraceLogging bool
+			if !cmdCrawlFlags.disableDetailedFindings {
+				detailedOutputWriter = cmd.OutOrStdout()
+				enableTraceLogging = cmdCrawlFlags.enableTraceLogging
+			}
+
+			var filepathMatchFunc func(string) (bool, error)
+			if skipOwnerCheck {
+				filepathMatchFunc = func(string) (bool, error) {
+					return true, nil
+				}
+			} else {
+				filepathMatchFunc = (&deleter.FileOwnerMatchers{
+					Matchers:     ms,
+					ResolveOwner: snifferos.OwnerUsername,
+				}).Match
+			}
+
+			_, err = crawler.Crawl(cmd.Context(), crawlConfig, deleter.Deleter{
+				Logger: log.Logger{
+					OutputWriter:       detailedOutputWriter,
+					ErrorWriter:        cmd.OutOrStderr(),
+					EnableTraceLogging: enableTraceLogging,
+				},
+				FilepathMatch: filepathMatchFunc,
+				FindingMatch: func(finding crawl.Finding) bool {
+					return crawl.AllFindingsSatisfiedBy(minimumFindingsRequirement, finding)
+				},
+				DryRun: dryRun,
+				Delete: os.Remove,
+			}.Process, cmd.OutOrStdout(), cmd.OutOrStderr())
+			return err
+		},
+	}
+	applyCrawlFlags(&cmd, &cmdCrawlFlags)
+	cmd.Flags().BoolVar(&dryRun, "dry-run", true, "When true, a line with be output instead of deleting a file. Use --dry-run=false to enable deletion.")
+	cmd.Flags().BoolVar(&skipOwnerCheck, "skip-owner-check", false, "When provided, the owner of a file will not be checked before attempting a delete.")
+	cmd.Flags().StringSliceVar(&directoriesWithOwners, "directory-with-owner", nil, `Provide a directory pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
+Multiple values can be provided and values must be provided in the form directory_pattern:owner_template, where a directory pattern and owner template are colon separated.
+
+When a file is deemed to be vulnerable, the directory containing the file will be matched against all directory patterns.
+For all directory matches, the owner template will be expanded against the directory pattern match to resolve to a file owner value that the actual file owner will then be compared against.
+Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the directory pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
+
+If no directories match, the file will not be deleted. If any directories match, all matching directory corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.  
+
+Examples:
+--directory-owner ^/foo/bar:qux would consider /foo/bar/baz for deletion only if it is owned by qux
+--directory-owner ^/foo/bar/:qux and --directory-owner ^/foo/bar/baz:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match
+--directory-owner ^/foo/(\w+):$1 would consider /foo/bar/baz for deletion only if it is owned by bar 
+`)
+	cmd.Flags().StringSliceVar(&findingsMatches, "finding-match", nil, `When supplied, any vulnerable finding must contain all values that are provided to finding-match for it to be considered for deletion.
+These values are considered on a finding-by-finding basis, i.e. an archive containing two separate vulnerable jars will only be deleted if either of the contained jars matches all finding-match values.
+
+Supported values are as follows:
+`+strings.Join(prefixAll(crawl.SupportedVulnerableFindingValues(), "- "), "\n")+`
+
+Example:
+--finding-match classFileMd5 and --finding-match jarFileObfuscated would only delete a file containing a vulnerability if the vulnerability contains a class file hash match and an obfuscated jar name.
+If a vulnerable finding contained only one of these finding-match values then the file would not be considered for deletion.
+`)
+	return &cmd
+}
+
+func prefixAll(vals []string, prefix string) []string {
+	for i := range vals {
+		vals[i] = prefix + vals[i]
+	}
+	return vals
+}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 
@@ -84,7 +83,6 @@ When used on windows, deleting based on file ownership is unsupported and skip-o
 				FilepathMatch: filepathMatch,
 				FindingMatch:  findingMatch,
 				DryRun:        dryRun,
-				Delete:        os.Remove,
 			}.Process, cmd.OutOrStdout(), cmd.OutOrStderr())
 			return err
 		},

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -32,17 +32,17 @@ import (
 
 func deleteCmd() *cobra.Command {
 	var (
-		cmdCrawlFlags         crawlFlags
-		dryRun                bool
-		skipOwnerCheck        bool
-		directoriesWithOwners []string
-		findingsMatches       []string
+		cmdCrawlFlags   crawlFlags
+		dryRun          bool
+		skipOwnerCheck  bool
+		filepathOwners  []string
+		findingsMatches []string
 	)
 	cmd := cobra.Command{
 		Use: "delete <root>",
 		Example: `Delete all findings nested beneath /path/to/dir that are owned by foo and contain findings that match both classFileMd5 and jarFileObfuscated.
 
-log4j-sniffer delete /path/to/dir --dry-run=false --directory-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated`,
+log4j-sniffer delete /path/to/dir --dry-run=false --filepath-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated`,
 		Short: "Delete files containing log4j vulnerabilities",
 		Long: `Delete files containing log4j vulnerabilities.
 
@@ -53,7 +53,7 @@ Dry-run mode is enabled by default, where a line will be output to state where a
 It is recommended to run using dry-run mode enabled, checking the logged output and then running with dry-run disabled using the same configuration flags.
 Use --dry-run=false to turn off dry-run mode, enabling deletes.
 
-When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of directory-with-owner.
+When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of filepath-owner.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -62,14 +62,14 @@ When used on windows, deleting based on file ownership is unsupported and skip-o
 				return err
 			}
 
-			if len(directoriesWithOwners) > 0 && skipOwnerCheck {
-				return errors.New("--directory-with-owner and --skip-owner-check cannot be used together")
+			if len(filepathOwners) > 0 && skipOwnerCheck {
+				return errors.New("--filepath-owner and --skip-owner-check cannot be used together")
 			}
-			if len(directoriesWithOwners) == 0 && !skipOwnerCheck {
-				return errors.New("at least one --directory-with-owner value must be provided or --skip-owner-check must be set")
+			if len(filepathOwners) == 0 && !skipOwnerCheck {
+				return errors.New("at least one --filepath-owner value must be provided or --skip-owner-check must be set")
 			}
 
-			filepathMatch, err := filepathMatcher(skipOwnerCheck, directoriesWithOwners)
+			filepathMatch, err := filepathMatcher(skipOwnerCheck, filepathOwners)
 			if err != nil {
 				return err
 			}
@@ -92,19 +92,19 @@ When used on windows, deleting based on file ownership is unsupported and skip-o
 	applyCrawlFlags(&cmd, &cmdCrawlFlags)
 	cmd.Flags().BoolVar(&dryRun, "dry-run", true, "When true, a line with be output instead of deleting a file. Use --dry-run=false to enable deletion.")
 	cmd.Flags().BoolVar(&skipOwnerCheck, "skip-owner-check", false, "When provided, the owner of a file will not be checked before attempting a delete.")
-	cmd.Flags().StringSliceVar(&directoriesWithOwners, "directory-with-owner", nil, `Provide a directory pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
-Multiple values can be provided and values must be provided in the form directory_pattern:owner_template, where a directory pattern and owner template are colon separated.
+	cmd.Flags().StringSliceVar(&filepathOwners, "filepath-owner", nil, `Provide a filepath pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
+Multiple values can be provided and values must be provided in the form filepath_pattern:owner_template, where a filepath pattern and owner template are colon separated.
 
-When a file is deemed to be vulnerable, the directory containing the file will be matched against all directory patterns.
-For all directory matches, the owner template will be expanded against the directory pattern match to resolve to a file owner value that the actual file owner will then be compared against.
-Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the directory pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
+When a file is deemed to be vulnerable, the path of the file containing the vulnerability will be matched against all filepath patterns.
+For all filepath matches, the owner template will be expanded against the filepath pattern match to resolve to a file owner value that the actual file owner will then be compared against.
+Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the filepath pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.
 
-If no directories match, the file will not be deleted. If any directories match, all matching directory corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.  
+If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.  
 
 Examples:
---directory-owner ^/foo/bar:qux would consider /foo/bar/baz for deletion only if it is owned by qux
---directory-owner ^/foo/bar/:qux and --directory-owner ^/foo/bar/baz:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match
---directory-owner ^/foo/(\w+):$1 would consider /foo/bar/baz for deletion only if it is owned by bar 
+--filepath-owner ^/foo/bar/.+:qux would consider /foo/bar/baz for deletion only if it is owned by qux.
+--filepath-owner ^/foo/bar/.+:qux and --filepath-owner ^/foo/bar/baz/.+:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match.
+--filepath-owner ^/foo/(\w+)/.*:$1 would consider /foo/bar/baz for deletion only if it is owned by bar.
 `)
 	cmd.Flags().StringSliceVar(&findingsMatches, "finding-match", nil, `When supplied, any vulnerable finding must contain all values that are provided to finding-match for it to be considered for deletion.
 These values are considered on a finding-by-finding basis, i.e. an archive containing two separate vulnerable jars will only be deleted if either of the contained jars matches all finding-match values.
@@ -147,7 +147,7 @@ func minimumFindingMatch(findingsMatches []string) (func(finding crawl.Finding) 
 	}, nil
 }
 
-func filepathMatcher(skipOwnerCheck bool, directoriesWithOwners []string) (func(string) (bool, error), error) {
+func filepathMatcher(skipOwnerCheck bool, filepathOwners []string) (func(string) (bool, error), error) {
 	if skipOwnerCheck {
 		return func(string) (bool, error) {
 			return true, nil
@@ -155,18 +155,18 @@ func filepathMatcher(skipOwnerCheck bool, directoriesWithOwners []string) (func(
 	}
 
 	var ms []deleter.Matcher
-	for _, value := range directoriesWithOwners {
+	for _, value := range filepathOwners {
 		split := strings.Split(value, ":")
 		if len(split) != 2 {
-			return nil, fmt.Errorf(`invalid directory-with-owner, must contain 2 colon-separated segments but got %q`, value)
+			return nil, fmt.Errorf(`invalid filepath-owner, must contain 2 colon-separated segments but got %q`, value)
 		}
 		expr, err := regexp.Compile(split[0])
 		if err != nil {
-			return nil, fmt.Errorf("error compiling pattern for directory-with-owner %s: %w", value, err)
+			return nil, fmt.Errorf("error compiling pattern for filepath-owner %s: %w", value, err)
 		}
 		ms = append(ms, deleter.TemplatedOwner{
-			DirectoryExpression: expr,
-			OwnerTemplate:       split[1],
+			FilepathExpression: expr,
+			OwnerTemplate:      split[1],
 		})
 	}
 

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -55,7 +55,7 @@ func TestDeleteCmd(t *testing.T) {
 		var err bytes.Buffer
 		cmd.SetErr(&err)
 		require.Error(t, cmd.Execute())
-		assert.Equal(t, "Error: invalid finding-match 🧨, supported values are classBytecodeInstructionMd5, classBytecodePartialMatch, classFileMd5, jarFileObfuscated, jarName, jarNameInsideArchive, jndiLookupClassName, jndiLookupClassPackageAndName, jndiManagerClassName, jndiManagerClassPackageAndName\n", err.String())
+		assert.Equal(t, "Error: invalid finding-match 🧨, supported values are ClassBytecodeInstructionMd5, ClassBytecodePartialMatch, ClassFileMd5, JarFileObfuscated, JarName, JarNameInsideArchive, JndiLookupClassName, JndiLookupClassPackageAndName, JndiManagerClassName, JndiManagerClassPackageAndName\n", err.String())
 	})
 
 	t.Run("runs successfully against directory with no flags", func(t *testing.T) {

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCmd(t *testing.T) {
+	t.Run("errors when no directory-with-owner provided and skip-owner-check not set", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"path"})
+		cmd.SetOut(io.Discard)
+		var err bytes.Buffer
+		cmd.SetErr(&err)
+		require.Error(t, cmd.Execute())
+		assert.Equal(t, err.String(), "Error: at least one --directory-with-owner value must be provided or --skip-owner-check must be set\n")
+	})
+
+	t.Run("errors when directory-with-owner and skip-owner-check both provided", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"path", "--directory-with-owner", "foo", "--skip-owner-check"})
+		cmd.SetOut(io.Discard)
+		var err bytes.Buffer
+		cmd.SetErr(&err)
+		require.Error(t, cmd.Execute())
+		assert.Equal(t, err.String(), "Error: --directory-with-owner and --skip-owner-check cannot be used together\n")
+	})
+
+	t.Run("errors when invalid findings match values provided", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"path", "--directory-with-owner", "foo:bar", "--finding-match", "jarName", "--finding-match", "🧨"})
+		cmd.SetOut(io.Discard)
+		var err bytes.Buffer
+		cmd.SetErr(&err)
+		require.Error(t, cmd.Execute())
+		assert.Equal(t, "Error: invalid finding-match 🧨, supported values are classBytecodeInstructionMd5, classBytecodePartialMatch, classFileMd5, jarFileObfuscated, jarName, jarNameInsideArchive, jndiLookupClassName, jndiLookupClassPackageAndName, jndiManagerClassName, jndiManagerClassPackageAndName\n", err.String())
+	})
+
+	t.Run("runs successfully against directory with no flags", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"foo"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		require.Error(t, cmd.Execute())
+	})
+
+	t.Run("errors when invalid directory with owner provided", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"foo", "--directory-with-owner", "foo"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		require.EqualError(t, cmd.Execute(), `invalid directory-with-owner, must contain 2 colon-separated segments but got "foo"`)
+	})
+
+	t.Run("errors when one of many directory with owner provided is invalid", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"foo", "--directory-with-owner", "foo:bar", "--directory-with-owner", "baz"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		require.EqualError(t, cmd.Execute(), `invalid directory-with-owner, must contain 2 colon-separated segments but got "baz"`)
+	})
+
+	t.Run("errors when directory with owner pattern cannot be created", func(t *testing.T) {
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{"foo", "--directory-with-owner", "**:bar"})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `error compiling pattern for directory-with-owner **:bar`)
+	})
+
+	t.Run("Runs deletions in dry-mode by default", func(t *testing.T) {
+		examples := []string{
+			"multiple_bad_versions/log4j-core-2.10.0.jar",
+			"multiple_bad_versions/log4j-core-2.11.0.jar",
+			"renamed_jar_class_file_extensions/not-a-finding.jar",
+		}
+		dir := setupExamplesDir(t, examples...)
+		cmd := deleteCmd()
+		current, err := user.Current()
+		require.NoError(t, err)
+		cmd.SetArgs([]string{dir, "--directory-with-owner", dir + ".*:" + current.Username})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+		assert.Contains(t, out.String(), "[INFO] Dry-run: would delete "+filepath.Join(dir, "multiple_bad_versions/log4j-core-2.10.0.jar"))
+		assert.Contains(t, out.String(), "[INFO] Dry-run: would delete "+filepath.Join(dir, "multiple_bad_versions/log4j-core-2.11.0.jar"))
+		assert.NotContains(t, out.String(), "[INFO] Dry-run: would delete "+filepath.Join(dir, "renamed_jar_class_file_extensions/not-a-finding.jar"))
+	})
+
+	t.Run("Does not delete when finding-match not reached", func(t *testing.T) {
+		examples := []string{
+			"multiple_bad_versions/log4j-core-2.10.0.jar",
+			"multiple_bad_versions/log4j-core-2.11.0.jar",
+			"renamed_jar_class_file_extensions/not-a-finding.jar",
+		}
+		dir := setupExamplesDir(t, examples...)
+		cmd := deleteCmd()
+		current, err := user.Current()
+		require.NoError(t, err)
+		cmd.SetArgs([]string{dir, "--directory-with-owner", dir + ".*:" + current.Username, "--finding-match", "jarNameInsideArchive"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+		_, err = os.Stat(filepath.Join(dir, "multiple_bad_versions/log4j-core-2.10.0.jar"))
+		assert.NoError(t, err)
+		_, err = os.Stat(filepath.Join(dir, "multiple_bad_versions/log4j-core-2.11.0.jar"))
+		assert.NoError(t, err)
+		_, err = os.Stat(filepath.Join(dir, "renamed_jar_class_file_extensions/not-a-finding.jar"))
+		assert.NoError(t, err)
+	})
+
+	t.Run("Deletes findings when dry-run=false with directory-with-owner", func(t *testing.T) {
+		examples := []string{
+			"multiple_bad_versions/log4j-core-2.10.0.jar",
+			"multiple_bad_versions/log4j-core-2.11.0.jar",
+			"renamed_jar_class_file_extensions/not-a-finding.jar",
+		}
+		dir := setupExamplesDir(t, examples...)
+		cmd := deleteCmd()
+		current, err := user.Current()
+		require.NoError(t, err)
+		cmd.SetArgs([]string{dir, "--dry-run=false", "--directory-with-owner", dir + ".*:" + current.Username})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+		var found []string
+		require.NoError(t, filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+			if !info.IsDir() {
+				found = append(found, path)
+			}
+			return nil
+		}))
+		assert.Equal(t, []string{filepath.Join(dir, "renamed_jar_class_file_extensions/not-a-finding.jar")}, found,
+			"bad versions should not still be found")
+	})
+
+	t.Run("Deletes findings when dry-run=false with skip-owner-check", func(t *testing.T) {
+		examples := []string{
+			"multiple_bad_versions/log4j-core-2.10.0.jar",
+			"multiple_bad_versions/log4j-core-2.11.0.jar",
+			"renamed_jar_class_file_extensions/not-a-finding.jar",
+		}
+		dir := setupExamplesDir(t, examples...)
+		cmd := deleteCmd()
+		cmd.SetArgs([]string{dir, "--dry-run=false", "--skip-owner-check"})
+		var out bytes.Buffer
+		cmd.SetOut(&out)
+		require.NoError(t, cmd.Execute())
+		var found []string
+		require.NoError(t, filepath.Walk(dir, func(path string, info fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() {
+				found = append(found, path)
+			}
+			return nil
+		}))
+		assert.Equal(t, []string{filepath.Join(dir, "renamed_jar_class_file_extensions/not-a-finding.jar")}, found,
+			"bad versions should not still be found")
+	})
+}
+
+func setupExamplesDir(t *testing.T, names ...string) string {
+	dir := t.TempDir()
+	for _, name := range names {
+		existing, err := os.Open(filepath.Join("../examples", name))
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, existing.Close()) }()
+		newPath := filepath.Join(dir, name)
+		dir, _ := filepath.Split(newPath)
+		require.NoError(t, os.MkdirAll(dir, 0700))
+		new, err := os.Create(newPath)
+		require.NoError(t, err)
+		defer func() { assert.NoError(t, new.Close()) }()
+		_, err = io.Copy(new, existing)
+		require.NoError(t, err)
+	}
+	return dir
+}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -65,7 +65,7 @@ A max depth of 0 will open up an archive on the filesystem but not any nested ar
 	cmd.Flags().BoolVar(&flags.enablePartialMatchingOnAllClasses, "enable-partial-matching-on-all-classes", false, `Enable partial bytecode matching to all class files found.`)
 	cmd.Flags().IntVar(&flags.obfuscatedClassNameAverageLength, "maximum-average-obfuscated-class-name-length", 3, `The maximum class name length for a class to be considered obfuscated.`)
 	cmd.Flags().IntVar(&flags.obfuscatedPackageNameAverageLength, "maximum-average-obfuscated-package-name-length", 3, `The maximum average package name length a class to be considered obfuscated.`)
-	cmd.Flags().BoolVar(&flags.enableTraceLogging, "enable-trace-logging", false, `Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect`)
+	cmd.Flags().BoolVar(&flags.enableTraceLogging, "enable-trace-logging", false, `Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect.`)
 }
 
 func createCrawlConfig(root string, flags crawlFlags) (crawler.Config, error) {

--- a/internal/crawler/crawl_test.go
+++ b/internal/crawler/crawl_test.go
@@ -268,11 +268,12 @@ func TestCrawlExamplesFindings(t *testing.T) {
 		ObfuscatedClassNameAverageLength:   3,
 		ObfuscatedPackageNameAverageLength: 3,
 		PrintDetailedOutput:                true,
-	}, func(ctx context.Context, path crawl.Path, result crawl.Finding, versions crawl.Versions) {
+	}, func(ctx context.Context, path crawl.Path, result crawl.Finding, versions crawl.Versions) bool {
 		findings[path.Joined()] = versionedFindings{
 			finding:  result,
 			versions: versions,
 		}
+		return true
 	}, io.Discard, io.Discard)
 
 	require.NoError(t, err)
@@ -323,11 +324,12 @@ func TestCrawlFindsJarNameWithoutWalking(t *testing.T) {
 		ObfuscatedClassNameAverageLength:   3,
 		ObfuscatedPackageNameAverageLength: 3,
 		PrintDetailedOutput:                true,
-	}, func(ctx context.Context, path crawl.Path, result crawl.Finding, versions crawl.Versions) {
+	}, func(ctx context.Context, path crawl.Path, result crawl.Finding, versions crawl.Versions) bool {
 		findings[path.Joined()] = versionedFindings{
 			finding:  result,
 			versions: versions,
 		}
+		return true
 	}, io.Discard, io.Discard)
 	require.NoError(t, err)
 	assert.Equal(t, crawl.Stats{

--- a/internal/deleter/delete.go
+++ b/internal/deleter/delete.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+import (
+	"context"
+
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/palantir/log4j-sniffer/pkg/log"
+)
+
+// Deleter will delete files containing vulnerable findings given they match certain criteria.
+type Deleter struct {
+	Logger        log.Logger
+	FilepathMatch func(filepath string) (bool, error)
+	FindingMatch  func(finding crawl.Finding) bool
+	DryRun        bool
+	Delete        func(filepath string) error
+}
+
+// Process a finding and delete it if it is eligible for deletion given certain configuration criteria.
+//
+// If the filepath and detailed finding both match for a given crawl.Path then a file is eligible for deletion.
+// In this case, Process will always return false to state that this file should no longer exist and that inspecting
+// this file for more findings should  not be undertaken.
+//
+// When Deleter.DryRun is true then a line will be logged stating that the file would be deleted.
+// When Deleter.Delete is false, then the configured function Delete will be called to delete the file.
+func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Finding, _ crawl.Versions) bool {
+	if len(path) == 0 {
+		return true
+	}
+	match, err := d.FilepathMatch(path[0])
+	if err != nil {
+		d.Logger.Error("Error matching file %s: %s", path[0], err)
+		return true
+	}
+	if !match {
+		return true
+	}
+	if !d.FindingMatch(finding) {
+		return true
+	}
+	if d.DryRun {
+		d.Logger.Info("Dry-run: would delete %s", path[0])
+		return false
+	}
+	if err := d.Delete(path[0]); err != nil {
+		d.Logger.Error("Error deleting file %s: %s", path[0], err.Error())
+	} else {
+		d.Logger.Info("Deleted file %s", path[0])
+	}
+	return false
+}

--- a/internal/deleter/delete.go
+++ b/internal/deleter/delete.go
@@ -16,6 +16,7 @@ package deleter
 
 import (
 	"context"
+	"os"
 
 	"github.com/palantir/log4j-sniffer/pkg/crawl"
 	"github.com/palantir/log4j-sniffer/pkg/log"
@@ -27,7 +28,6 @@ type Deleter struct {
 	FilepathMatch func(filepath string) (bool, error)
 	FindingMatch  func(finding crawl.Finding) bool
 	DryRun        bool
-	Delete        func(filepath string) error
 }
 
 // Process a finding and delete it if it is eligible for deletion given certain configuration criteria.
@@ -61,7 +61,7 @@ func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Fin
 		d.Logger.Info("Dry-run: would delete %s", filepath)
 		return false
 	}
-	if err := d.Delete(filepath); err != nil {
+	if err := os.Remove(filepath); err != nil {
 		d.Logger.Error("Error deleting file %s: %s", filepath, err.Error())
 	} else {
 		d.Logger.Info("Deleted file %s", filepath)

--- a/internal/deleter/delete.go
+++ b/internal/deleter/delete.go
@@ -34,7 +34,7 @@ type Deleter struct {
 //
 // If the filepath and detailed finding both match for a given crawl.Path then a file is eligible for deletion.
 // In this case, Process will always return false to state that this file should no longer exist and that inspecting
-// this file for more findings should  not be undertaken.
+// this file for more findings should not be undertaken.
 //
 // When Deleter.DryRun is true then a line will be logged stating that the file would be deleted.
 // When Deleter.Delete is false, then the configured function Delete will be called to delete the file.
@@ -42,9 +42,10 @@ func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Fin
 	if len(path) == 0 {
 		return true
 	}
-	match, err := d.FilepathMatch(path[0])
+	filepath := path[0]
+	match, err := d.FilepathMatch(filepath)
 	if err != nil {
-		d.Logger.Error("Error matching file %s: %s", path[0], err)
+		d.Logger.Error("Error matching file %s: %s", filepath, err)
 		return true
 	}
 	if !match {
@@ -54,13 +55,13 @@ func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Fin
 		return true
 	}
 	if d.DryRun {
-		d.Logger.Info("Dry-run: would delete %s", path[0])
+		d.Logger.Info("Dry-run: would delete %s", filepath)
 		return false
 	}
-	if err := d.Delete(path[0]); err != nil {
-		d.Logger.Error("Error deleting file %s: %s", path[0], err.Error())
+	if err := d.Delete(filepath); err != nil {
+		d.Logger.Error("Error deleting file %s: %s", filepath, err.Error())
 	} else {
-		d.Logger.Info("Deleted file %s", path[0])
+		d.Logger.Info("Deleted file %s", filepath)
 	}
 	return false
 }

--- a/internal/deleter/delete_test.go
+++ b/internal/deleter/delete_test.go
@@ -27,6 +27,17 @@ import (
 )
 
 func TestDeleter_Delete(t *testing.T) {
+	t.Run("nil match functions act as match-all", func(t *testing.T) {
+		var filepath string
+		deleter.Deleter{
+			Delete: func(f string) error {
+				filepath = f
+				return nil
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 1, nil)
+		assert.Equal(t, "foo", filepath)
+	})
+
 	t.Run("logs error on filepath match error", func(t *testing.T) {
 		var err bytes.Buffer
 		deleter.Deleter{

--- a/internal/deleter/delete_test.go
+++ b/internal/deleter/delete_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/palantir/log4j-sniffer/internal/deleter"
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/palantir/log4j-sniffer/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleter_Delete(t *testing.T) {
+	t.Run("logs error on filepath match error", func(t *testing.T) {
+		var err bytes.Buffer
+		deleter.Deleter{
+			Logger: log.Logger{
+				ErrorWriter: &err,
+			},
+			FilepathMatch: func(string) (bool, error) { return true, errors.New("some err") },
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 0, nil)
+		assert.Equal(t, "[ERROR] Error matching file foo: some err\n", err.String())
+	})
+
+	t.Run("logs matchers missing when no matchers configured", func(t *testing.T) {
+		var path string
+		deleter.Deleter{
+			FilepathMatch: func(p string) (bool, error) {
+				path = p
+				return false, nil
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 0, nil)
+		assert.Equal(t, "foo", path)
+	})
+
+	t.Run("passes first path segment to FilepathMatch", func(t *testing.T) {
+		var path string
+		deleter.Deleter{
+			FilepathMatch: func(p string) (bool, error) {
+				path = p
+				return false, nil
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 0, nil)
+		assert.Equal(t, "foo", path)
+	})
+
+	t.Run("passes finding to finding matcher if path matches", func(t *testing.T) {
+		var finding crawl.Finding
+		deleter.Deleter{
+			FilepathMatch: func(string) (bool, error) { return true, nil },
+			FindingMatch: func(f crawl.Finding) bool {
+				finding = f
+				return false
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 600, nil)
+		assert.Equal(t, crawl.Finding(600), finding)
+	})
+
+	t.Run("logs dry mode if running in dry mode", func(t *testing.T) {
+		var out bytes.Buffer
+		deleter.Deleter{
+			Logger: log.Logger{
+				OutputWriter: &out,
+			},
+			FilepathMatch: func(string) (bool, error) { return true, nil },
+			FindingMatch:  func(crawl.Finding) bool { return true },
+			DryRun:        true,
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 600, nil)
+		assert.Equal(t, "[INFO] Dry-run: would delete foo\n", out.String())
+	})
+
+	t.Run("deletes file if filepath and finding match", func(t *testing.T) {
+		var path string
+		var out bytes.Buffer
+		deleter.Deleter{
+			Logger: log.Logger{
+				OutputWriter: &out,
+			},
+			FilepathMatch: func(string) (bool, error) { return true, nil },
+			FindingMatch:  func(crawl.Finding) bool { return true },
+			Delete: func(p string) error {
+				path = p
+				return nil
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 600, nil)
+		assert.Equal(t, "foo", path)
+		assert.Equal(t, "[INFO] Deleted file foo\n", out.String())
+	})
+
+	t.Run("logs error if error deleting file", func(t *testing.T) {
+		var path string
+		var err bytes.Buffer
+		deleter.Deleter{
+			Logger: log.Logger{
+				ErrorWriter: &err,
+			},
+			FilepathMatch: func(string) (bool, error) { return true, nil },
+			FindingMatch:  func(crawl.Finding) bool { return true },
+			Delete: func(p string) error {
+				path = p
+				return errors.New("some error")
+			},
+		}.Process(context.Background(), crawl.Path{"foo", "bar"}, 600, nil)
+		assert.Equal(t, "foo", path)
+		assert.Equal(t, "[ERROR] Error deleting file foo: some error\n", err.String())
+	})
+}

--- a/internal/deleter/ownerscope.go
+++ b/internal/deleter/ownerscope.go
@@ -30,7 +30,7 @@ func (ms FileOwnerMatchers) Match(path string) (bool, error) {
 		owner         string
 	)
 	for _, matcher := range ms.Matchers {
-		if !matcher.DirectoryMatch(path) {
+		if !matcher.FilepathMatch(path) {
 			continue
 		}
 		dirMatchFound = true
@@ -50,6 +50,6 @@ func (ms FileOwnerMatchers) Match(path string) (bool, error) {
 
 // Matcher determine whether a directory and owner match some given constraints.
 type Matcher interface {
-	DirectoryMatch(filepath string) bool
+	FilepathMatch(filepath string) bool
 	OwnerMatch(filepath, owner string) bool
 }

--- a/internal/deleter/ownerscope.go
+++ b/internal/deleter/ownerscope.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+// FileOwnerMatchers matches the owner of a given file against an amount of Matchers,
+// using the contained function to resolve the owner of a path.
+type FileOwnerMatchers struct {
+	Matchers     []Matcher
+	ResolveOwner func(path string) (string, error)
+}
+
+// Match resolves the owner of the given path and checks ownership of the file against the contained Matchers.
+// Match will yield true if more than 0 matchers match the directory that contains the filepath at path, and
+// all of those matchers return true from their OwnerMatch method.
+func (ms FileOwnerMatchers) Match(path string) (bool, error) {
+	var (
+		directoryMatches int
+		owner            string
+	)
+	for _, match := range ms.Matchers {
+		if !match.DirectoryMatch(path) {
+			continue
+		}
+		directoryMatches++
+		if owner == "" {
+			var err error
+			owner, err = ms.ResolveOwner(path)
+			if err != nil {
+				return false, err
+			}
+		}
+		if !match.OwnerMatch(path, owner) {
+			return false, nil
+		}
+	}
+	return directoryMatches > 0, nil
+}
+
+// Matcher determine whether a directory and owner match some given constraints.
+type Matcher interface {
+	DirectoryMatch(filepath string) bool
+	OwnerMatch(filepath, owner string) bool
+}

--- a/internal/deleter/ownerscope.go
+++ b/internal/deleter/ownerscope.go
@@ -26,14 +26,14 @@ type FileOwnerMatchers struct {
 // all of those matchers return true from their OwnerMatch method.
 func (ms FileOwnerMatchers) Match(path string) (bool, error) {
 	var (
-		directoryMatches int
-		owner            string
+		dirMatchFound bool
+		owner         string
 	)
-	for _, match := range ms.Matchers {
-		if !match.DirectoryMatch(path) {
+	for _, matcher := range ms.Matchers {
+		if !matcher.DirectoryMatch(path) {
 			continue
 		}
-		directoryMatches++
+		dirMatchFound = true
 		if owner == "" {
 			var err error
 			owner, err = ms.ResolveOwner(path)
@@ -41,11 +41,11 @@ func (ms FileOwnerMatchers) Match(path string) (bool, error) {
 				return false, err
 			}
 		}
-		if !match.OwnerMatch(path, owner) {
+		if !matcher.OwnerMatch(path, owner) {
 			return false, nil
 		}
 	}
-	return directoryMatches > 0, nil
+	return dirMatchFound, nil
 }
 
 // Matcher determine whether a directory and owner match some given constraints.

--- a/internal/deleter/ownerscope_test.go
+++ b/internal/deleter/ownerscope_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileOwnerMatcher_Match(t *testing.T) {
+	t.Run("no directory owners does not match anything", func(t *testing.T) {
+		match, err := FileOwnerMatchers{}.Match("")
+		require.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("errors from resolve owner is returned", func(t *testing.T) {
+		expectedErr := errors.New("err")
+		_, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) {
+				return "", expectedErr
+			},
+			Matchers: []Matcher{
+				stubMatcher{directoryMatch: func(path string) bool { return true }}},
+		}.Match("path")
+		assert.Equal(t, expectedErr, err)
+	})
+
+	t.Run("passes path and owner to matchers", func(t *testing.T) {
+		var calls []string
+		_, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) {
+				return "owner", nil
+			},
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool {
+						calls = append(calls, "a")
+						assert.Equal(t, "path", path)
+						return true
+					},
+					ownerMatch: func(path, owner string) bool {
+						calls = append(calls, "b")
+						assert.Equal(t, "path", path)
+						assert.Equal(t, "owner", owner)
+						return true
+					},
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool {
+						calls = append(calls, "c")
+						assert.Equal(t, "path", path)
+						return true
+					},
+					ownerMatch: func(path, owner string) bool {
+						calls = append(calls, "d")
+						assert.Equal(t, "path", path)
+						assert.Equal(t, "owner", owner)
+						return true
+					},
+				}},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b", "c", "d"}, calls, "expected calls to functions to be in order")
+	})
+
+	t.Run("does not call owner matchers funcs if directory miss", func(t *testing.T) {
+		var calls []string
+		_, err := FileOwnerMatchers{
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool {
+						calls = append(calls, "a")
+						return false
+					},
+					ownerMatch: func(path, owner string) bool {
+						require.FailNow(t, "should not have been called")
+						return true
+					},
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool {
+						calls = append(calls, "b")
+						return false
+					},
+					ownerMatch: func(path, owner string) bool {
+						require.FailNow(t, "should not have been called")
+						return true
+					},
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, calls, "expected calls to functions to be in order")
+	})
+
+	t.Run("no directory matches results in no match", func(t *testing.T) {
+		match, err := FileOwnerMatchers{
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return false },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return false },
+				},
+			},
+		}.Match("path")
+		assert.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("single directory match returns result of owner match", func(t *testing.T) {
+		match, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) { return "", nil },
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return false },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("multiple directory match returns false if any are owner misses", func(t *testing.T) {
+		match, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) { return "", nil },
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return false },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return false },
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("multiple directory match returns true if all are owner misses", func(t *testing.T) {
+		match, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) { return "", nil },
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return false },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.True(t, match)
+	})
+
+	t.Run("does not subsequent directory matchers if any directory has an owner miss", func(t *testing.T) {
+		match, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) { return "", nil },
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return false },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool {
+						require.FailNow(t, "should not be called")
+						return false
+					},
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.False(t, match)
+	})
+
+	t.Run("resolves owner once per file", func(t *testing.T) {
+		var resolves int
+		_, err := FileOwnerMatchers{
+			ResolveOwner: func(path string) (string, error) {
+				resolves++
+				return "foo", nil
+			},
+			Matchers: []Matcher{
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+				stubMatcher{
+					directoryMatch: func(path string) bool { return true },
+					ownerMatch:     func(path, owner string) bool { return true },
+				},
+			},
+		}.Match("path")
+		require.NoError(t, err)
+		assert.Equal(t, 1, resolves)
+	})
+}
+
+type stubMatcher struct {
+	directoryMatch func(path string) bool
+	ownerMatch     func(path, owner string) bool
+}
+
+func (s stubMatcher) DirectoryMatch(path string) bool {
+	return s.directoryMatch(path)
+}
+
+func (s stubMatcher) OwnerMatch(path, owner string) bool {
+	return s.ownerMatch(path, owner)
+}

--- a/internal/deleter/templatedowner.go
+++ b/internal/deleter/templatedowner.go
@@ -22,21 +22,20 @@ import (
 // TemplatedOwner provides a Matcher interface with flexible pattern matching behaviour to determine a file
 // ownership match based on a templated expression and regular expression.
 type TemplatedOwner struct {
-	DirectoryExpression *regexp.Regexp
-	OwnerTemplate       string
+	FilepathExpression *regexp.Regexp
+	OwnerTemplate      string
 }
 
-// DirectoryMatch returns true when the directory containing path matches the TemplatedOwner DirectoryExpression field.
-func (r TemplatedOwner) DirectoryMatch(path string) bool {
-	return r.DirectoryExpression.MatchString(filepath.Dir(path))
+// FilepathMatch returns true when the filepath of the finding matches the TemplatedOwner FilepathExpression field.
+func (r TemplatedOwner) FilepathMatch(path string) bool {
+	return r.FilepathExpression.MatchString(filepath.Dir(path))
 }
 
 // OwnerMatch returns true when owner of the file matches the result of the OwnerTemplate being expanded against the
-// DirectoryExpression regular expression.
+// FilepathExpression regular expression.
 // OwnerTemplate may contain variable names of the form $1 or $name which will be expanded against captured group
-// matches from the DirectoryExpression when it is matched against the directory containing the file at path.
+// matches from the FilepathExpression when it is matched against a filepath.
 // Please refer to the go regexp documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed behaviour.
 func (r TemplatedOwner) OwnerMatch(path, owner string) bool {
-	dir := filepath.Dir(path)
-	return string(r.DirectoryExpression.ExpandString(nil, r.OwnerTemplate, dir, r.DirectoryExpression.FindStringSubmatchIndex(dir))) == owner
+	return string(r.FilepathExpression.ExpandString(nil, r.OwnerTemplate, path, r.FilepathExpression.FindStringSubmatchIndex(path))) == owner
 }

--- a/internal/deleter/templatedowner.go
+++ b/internal/deleter/templatedowner.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+import (
+	"path/filepath"
+	"regexp"
+)
+
+// TemplatedOwner provides a Matcher interface with flexible pattern matching behaviour to determine a file
+// ownership match based on a templated expression and regular expression.
+type TemplatedOwner struct {
+	DirectoryExpression *regexp.Regexp
+	OwnerTemplate       string
+}
+
+// DirectoryMatch returns true when the directory containing path matches the TemplatedOwner DirectoryExpression field.
+func (r TemplatedOwner) DirectoryMatch(path string) bool {
+	dir, _ := filepath.Split(path)
+	return r.DirectoryExpression.MatchString(dir)
+}
+
+// OwnerMatch returns true when owner of the file matches the result of the OwnerTemplate being expanded against the
+// DirectoryExpression regular expression.
+// OwnerTemplate may contain variable names of the form $1 or $name which will be expanded against captured group
+// matches from the DirectoryExpression when it is matched against the directory containing the file at path.
+// Please refer to the go regexp documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed behaviour.
+func (r TemplatedOwner) OwnerMatch(path, owner string) bool {
+	dir, _ := filepath.Split(path)
+	return string(r.DirectoryExpression.ExpandString(nil, r.OwnerTemplate, dir, r.DirectoryExpression.FindStringSubmatchIndex(dir))) == owner
+}

--- a/internal/deleter/templatedowner.go
+++ b/internal/deleter/templatedowner.go
@@ -28,8 +28,7 @@ type TemplatedOwner struct {
 
 // DirectoryMatch returns true when the directory containing path matches the TemplatedOwner DirectoryExpression field.
 func (r TemplatedOwner) DirectoryMatch(path string) bool {
-	dir, _ := filepath.Split(path)
-	return r.DirectoryExpression.MatchString(dir)
+	return r.DirectoryExpression.MatchString(filepath.Dir(path))
 }
 
 // OwnerMatch returns true when owner of the file matches the result of the OwnerTemplate being expanded against the
@@ -38,6 +37,6 @@ func (r TemplatedOwner) DirectoryMatch(path string) bool {
 // matches from the DirectoryExpression when it is matched against the directory containing the file at path.
 // Please refer to the go regexp documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed behaviour.
 func (r TemplatedOwner) OwnerMatch(path, owner string) bool {
-	dir, _ := filepath.Split(path)
+	dir := filepath.Dir(path)
 	return string(r.DirectoryExpression.ExpandString(nil, r.OwnerTemplate, dir, r.DirectoryExpression.FindStringSubmatchIndex(dir))) == owner
 }

--- a/internal/deleter/templatedowner_test.go
+++ b/internal/deleter/templatedowner_test.go
@@ -24,15 +24,15 @@ import (
 func TestRegexWithSubstitutionMatcher(t *testing.T) {
 	t.Run("matches regex against path", func(t *testing.T) {
 		matcher := TemplatedOwner{
-			DirectoryExpression: regexp.MustCompile("/foo/bar/.*"),
+			FilepathExpression: regexp.MustCompile("/foo/bar/.*"),
 		}
-		assert.True(t, matcher.DirectoryMatch("someprefix/foo/bar/baz/qux"))
+		assert.True(t, matcher.FilepathMatch("someprefix/foo/bar/baz/qux"))
 	})
 
 	t.Run("makes substitution for owner match", func(t *testing.T) {
 		matcher := TemplatedOwner{
-			DirectoryExpression: regexp.MustCompile("/foo/(.+)"),
-			OwnerTemplate:       "owner $1",
+			FilepathExpression: regexp.MustCompile("/foo/(.+)/"),
+			OwnerTemplate:      "owner $1",
 		}
 		assert.True(t, matcher.OwnerMatch("/foo/bar/baz", "owner bar"))
 	})

--- a/internal/deleter/templatedowner_test.go
+++ b/internal/deleter/templatedowner_test.go
@@ -31,7 +31,7 @@ func TestRegexWithSubstitutionMatcher(t *testing.T) {
 
 	t.Run("makes substitution for owner match", func(t *testing.T) {
 		matcher := TemplatedOwner{
-			DirectoryExpression: regexp.MustCompile("/foo/(.+)/"),
+			DirectoryExpression: regexp.MustCompile("/foo/(.+)"),
 			OwnerTemplate:       "owner $1",
 		}
 		assert.True(t, matcher.OwnerMatch("/foo/bar/baz", "owner bar"))

--- a/internal/deleter/templatedowner_test.go
+++ b/internal/deleter/templatedowner_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexWithSubstitutionMatcher(t *testing.T) {
+	t.Run("matches regex against path", func(t *testing.T) {
+		matcher := TemplatedOwner{
+			DirectoryExpression: regexp.MustCompile("/foo/bar/.*"),
+		}
+		assert.True(t, matcher.DirectoryMatch("someprefix/foo/bar/baz/qux"))
+	})
+
+	t.Run("makes substitution for owner match", func(t *testing.T) {
+		matcher := TemplatedOwner{
+			DirectoryExpression: regexp.MustCompile("/foo/(.+)/"),
+			OwnerTemplate:       "owner $1",
+		}
+		assert.True(t, matcher.OwnerMatch("/foo/bar/baz", "owner bar"))
+	})
+}

--- a/internal/os/owner_unix.go
+++ b/internal/os/owner_unix.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package os
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+)
+
+// OwnerUsername will attempt to find the username of the owner of the file at path.
+// The underlying mechanism used to determine the username is most likely only supported
+// on Unix-like systems.
+func OwnerUsername(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", errors.New("value returned from os is unsupported")
+	}
+	u, err := user.LookupId(strconv.FormatUint(uint64(stat.Uid), 10))
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
+}

--- a/internal/os/owner_windows.go
+++ b/internal/os/owner_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+//go:build windows
+// +build windows
+
+package os
 
 import (
-	"github.com/palantir/pkg/cobracli"
-	"github.com/spf13/cobra"
+	"errors"
 )
 
-var (
-	Version = "unspecified"
-)
-
-func Execute() int {
-	rootCmd := &cobra.Command{
-		Use:   "log4j-sniffer",
-		Short: "Filesystem crawler to identify jars and java classes",
-	}
-	rootCmd.AddCommand(crawlCmd())
-	rootCmd.AddCommand(deleteCmd())
-	rootCmd.AddCommand(identifyCmd())
-	rootCmd.AddCommand(compareCmd())
-	return cobracli.ExecuteWithDefaultParams(rootCmd, cobracli.VersionFlagParam(Version))
+// OwnerUsername returns an error stating that this operation is unsupported on windows.
+func OwnerUsername(string) (string, error) {
+	return "", errors.New("unsupported on windows")
 }

--- a/pkg/crawl/finding.go
+++ b/pkg/crawl/finding.go
@@ -90,7 +90,7 @@ func invertedFindingStringMap() map[string]Finding {
 	for finding, s := range vulnerableFindingStrings {
 		_, exists := out[s]
 		if exists {
-			panic(fmt.Sprintf("finding already defined: %s", s))
+			panic(fmt.Sprintf("finding already defined when inverting finding strings map: %s", s))
 		}
 		out[s] = finding
 	}

--- a/pkg/crawl/finding.go
+++ b/pkg/crawl/finding.go
@@ -14,6 +14,102 @@
 
 package crawl
 
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	UnknownVersion = "unknown"
+
+	NothingDetected                Finding = 0
+	JndiLookupClassName            Finding = 1 << iota
+	JndiLookupClassPackageAndName  Finding = 1 << iota
+	JndiManagerClassName           Finding = 1 << iota
+	JarName                        Finding = 1 << iota
+	JarNameInsideArchive           Finding = 1 << iota
+	JndiManagerClassPackageAndName Finding = 1 << iota
+	JarFileObfuscated              Finding = 1 << iota
+	ClassBytecodePartialMatch      Finding = 1 << iota
+	ClassBytecodeInstructionMd5    Finding = 1 << iota
+	ClassFileMd5                   Finding = 1 << iota
+)
+
+var (
+	// vulnerableFindingStrings contains only the Finding values that are considered vulnerable.
+	vulnerableFindingStrings = map[Finding]string{
+		JndiLookupClassName:            "JndiLookupClassName",
+		JndiLookupClassPackageAndName:  "JndiLookupClassPackageAndName",
+		JndiManagerClassName:           "JndiManagerClassName",
+		JarName:                        "JarName",
+		JarNameInsideArchive:           "JarNameInsideArchive",
+		JndiManagerClassPackageAndName: "JndiManagerClassPackageAndName",
+		JarFileObfuscated:              "JarFileObfuscated",
+		ClassBytecodePartialMatch:      "ClassBytecodePartialMatch",
+		ClassBytecodeInstructionMd5:    "ClassBytecodeInstructionMd5",
+		ClassFileMd5:                   "ClassFileMd5",
+	}
+
+	stringFindings           = invertedFindingStringMap()
+	lowercasedStringFindings = lowerCasedInvertedFindingStringMap()
+)
+
+type Finding int
+type Versions map[string]struct{}
+
+// FindingOf creates a finding from a string, returning an error if a corresponding finding does not exist.
+// Conversion is case-insensitive.
+func FindingOf(v string) (Finding, error) {
+	finding, ok := lowercasedStringFindings[strings.ToLower(v)]
+	if !ok {
+		return 0, fmt.Errorf("invalid finding-match %s, supported values are %s", v, strings.Join(SupportedVulnerableFindingValues(), ", "))
+	}
+	return finding, nil
+}
+
+func SupportedVulnerableFindingValues() []string {
+	var supportedValues []string
+	for s := range stringFindings {
+		supportedValues = append(supportedValues, s)
+	}
+	sort.Strings(supportedValues)
+	return supportedValues
+}
+
+func lowerCasedInvertedFindingStringMap() map[string]Finding {
+	out := make(map[string]Finding)
+	for s, finding := range invertedFindingStringMap() {
+		out[strings.ToLower(s)] = finding
+	}
+	return out
+}
+
+func invertedFindingStringMap() map[string]Finding {
+	out := make(map[string]Finding)
+	for finding, s := range vulnerableFindingStrings {
+		_, exists := out[s]
+		if exists {
+			panic(fmt.Sprintf("finding already defined: %s", s))
+		}
+		out[s] = finding
+	}
+	return out
+}
+
+func (f Finding) String() string {
+	var out []string
+	// for all non-zero bits, append string for finding if it exists
+	for i := 0; f > 0; i, f = i+1, f>>1 {
+		if f&(1) > 0 {
+			if s, ok := vulnerableFindingStrings[1<<i]; ok {
+				out = append(out, s)
+			}
+		}
+	}
+	return strings.Join(out, ",")
+}
+
 // AllFindingsSatisfiedBy returns true if all the findings represented by a are also represented by b
 func AllFindingsSatisfiedBy(a, b Finding) bool {
 	// after bitwise and, result should equal exactly the requirements

--- a/pkg/crawl/finding.go
+++ b/pkg/crawl/finding.go
@@ -99,10 +99,12 @@ func invertedFindingStringMap() map[string]Finding {
 
 func (f Finding) String() string {
 	var out []string
-	// for all non-zero bits, append string for finding if it exists
-	for i := 0; f > 0; i, f = i+1, f>>1 {
-		if f&(1) > 0 {
-			if s, ok := vulnerableFindingStrings[1<<i]; ok {
+	// For each vulnerable finding type, aka non-zero Finding value,
+	// compare single bit against finding and append the string from
+	// that finding to the joined list.
+	for findingBit := Finding(1); f >= findingBit; findingBit <<= 1 {
+		if AllFindingsSatisfiedBy(findingBit, f) {
+			if s, ok := vulnerableFindingStrings[findingBit]; ok {
 				out = append(out, s)
 			}
 		}

--- a/pkg/crawl/finding.go
+++ b/pkg/crawl/finding.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,25 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package crawl
 
-import (
-	"github.com/palantir/pkg/cobracli"
-	"github.com/spf13/cobra"
-)
-
-var (
-	Version = "unspecified"
-)
-
-func Execute() int {
-	rootCmd := &cobra.Command{
-		Use:   "log4j-sniffer",
-		Short: "Filesystem crawler to identify jars and java classes",
-	}
-	rootCmd.AddCommand(crawlCmd())
-	rootCmd.AddCommand(deleteCmd())
-	rootCmd.AddCommand(identifyCmd())
-	rootCmd.AddCommand(compareCmd())
-	return cobracli.ExecuteWithDefaultParams(rootCmd, cobracli.VersionFlagParam(Version))
+// AllFindingsSatisfiedBy returns true if all the findings represented by a are also represented by b
+func AllFindingsSatisfiedBy(a, b Finding) bool {
+	// after bitwise and, result should equal exactly the requirements
+	return a&b == a
 }

--- a/pkg/crawl/finding_test.go
+++ b/pkg/crawl/finding_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl_test
+
+import (
+	"testing"
+
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllFindingsSatisfiedBy(t *testing.T) {
+	t.Run("no finding requirement returns true for any", func(t *testing.T) {
+		assert.True(t, crawl.AllFindingsSatisfiedBy(crawl.NothingDetected, crawl.NothingDetected))
+		assert.True(t, crawl.AllFindingsSatisfiedBy(crawl.NothingDetected, 1))
+	})
+
+	t.Run("non-zero requirement does not match nothing detected", func(t *testing.T) {
+		assert.False(t, crawl.AllFindingsSatisfiedBy(0b1, 0b0))
+	})
+
+	t.Run("exact bit match does match", func(t *testing.T) {
+		assert.True(t, crawl.AllFindingsSatisfiedBy(0b1, 0b1))
+	})
+
+	t.Run("actual finding missing bits does not match", func(t *testing.T) {
+		assert.False(t, crawl.AllFindingsSatisfiedBy(0b11, 0b1))
+	})
+}

--- a/pkg/crawl/identify.go
+++ b/pkg/crawl/identify.go
@@ -86,7 +86,7 @@ func invertedFindingStringMap() map[string]Finding {
 	for finding, s := range vulnerableFindingStrings {
 		_, exists := out[s]
 		if exists {
-			panic("finding already defined")
+			panic(fmt.Sprintf("finding already defined: %s", s))
 		}
 		out[s] = finding
 	}
@@ -154,8 +154,9 @@ type Log4jIdentifier struct {
 
 // HandleFindingFunc is called with the given findings and versions when Log4jIdentifier identifies
 // a log4j vulnerability whilst crawling the filesystem.
-// The bool returned by HandleFindingFunc, when false, will instruct the identification of the file to cease.
-// If the bool returned is true, identification will continue.
+// The bool returned by HandleFindingFunc, indicates whether identification within the file should continue or not.
+// For example, if the identification of a file has already yielded results that are desired for a given file,
+// then there may be no need for the identification of the file to continue.
 type HandleFindingFunc func(ctx context.Context, path Path, result Finding, version Versions) bool
 
 // Identify identifies vulnerable files, passing each finding along with its versions to the Log4jIdentifier's HandleFindingFunc.

--- a/pkg/crawl/identify.go
+++ b/pkg/crawl/identify.go
@@ -95,35 +95,13 @@ func invertedFindingStringMap() map[string]Finding {
 
 func (f Finding) String() string {
 	var out []string
-	if f&JndiLookupClassName > 0 {
-		out = append(out, "JndiLookupClassName")
-	}
-	if f&JndiLookupClassPackageAndName > 0 {
-		out = append(out, "JndiLookupClassPackageAndName")
-	}
-	if f&JndiManagerClassName > 0 {
-		out = append(out, "JndiManagerClassName")
-	}
-	if f&JarName > 0 {
-		out = append(out, "JarName")
-	}
-	if f&JarNameInsideArchive > 0 {
-		out = append(out, "JarNameInsideArchive")
-	}
-	if f&JndiManagerClassPackageAndName > 0 {
-		out = append(out, "JndiManagerClassPackageAndName")
-	}
-	if f&JarFileObfuscated > 0 {
-		out = append(out, "JarFileObfuscated")
-	}
-	if f&ClassBytecodePartialMatch > 0 {
-		out = append(out, "ClassBytecodePartialMatch")
-	}
-	if f&ClassBytecodeInstructionMd5 > 0 {
-		out = append(out, "ClassBytecodeInstructionMd5")
-	}
-	if f&ClassFileMd5 > 0 {
-		out = append(out, "ClassFileMd5")
+	// for all noon-zero bits, append string for finding if it exists
+	for i := 0; f > 0; i, f = i+1, f>>1 {
+		if f&(1) > 0 {
+			if s, ok := vulnerableFindingStrings[1<<i]; ok && len(s) > 1 {
+				out = append(out, strings.ToUpper(string(s[0]))+s[1:])
+			}
+		}
 	}
 	return strings.Join(out, ",")
 }

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -312,10 +312,15 @@ func TestFindingString(t *testing.T) {
 		Out string
 	}{
 		{},
+		{crawl.JndiLookupClassName, "JndiLookupClassName"},
+		{crawl.JndiLookupClassPackageAndName, "JndiLookupClassPackageAndName"},
 		{crawl.JndiManagerClassName, "JndiManagerClassName"},
 		{crawl.JarName, "JarName"},
 		{crawl.JarNameInsideArchive, "JarNameInsideArchive"},
 		{crawl.JndiManagerClassPackageAndName, "JndiManagerClassPackageAndName"},
+		{crawl.JarFileObfuscated, "JarFileObfuscated"},
+		{crawl.ClassBytecodePartialMatch, "ClassBytecodePartialMatch"},
+		{crawl.ClassBytecodeInstructionMd5, "ClassBytecodeInstructionMd5"},
 		{crawl.JndiManagerClassName | crawl.JarName, "JndiManagerClassName,JarName"},
 		{crawl.JndiManagerClassName | crawl.JndiManagerClassPackageAndName, "JndiManagerClassName,JndiManagerClassPackageAndName"},
 		{crawl.JndiManagerClassName | crawl.JarName | crawl.JndiManagerClassPackageAndName, "JndiManagerClassName,JarName,JndiManagerClassPackageAndName"},

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -286,7 +286,7 @@ func TestIdentifyFromArchiveContents(t *testing.T) {
 				ArchiveMaxDepth:    1,
 				ArchiveWalkTimeout: time.Second,
 				Limiter:            ratelimit.NewUnlimited(),
-				HandleFinding: func(ctx context.Context, path crawl.Path, result crawl.Finding, version crawl.Versions) {
+				HandleFinding: func(ctx context.Context, path crawl.Path, result crawl.Finding, version crawl.Versions) bool {
 					reported++
 					assert.Equal(t, tc.result, result)
 					if tc.version == "" {
@@ -294,6 +294,7 @@ func TestIdentifyFromArchiveContents(t *testing.T) {
 					} else {
 						assert.Equal(t, crawl.Versions{tc.version: {}}, version)
 					}
+					return true
 				},
 			}
 			_, err := identifier.Identify(context.Background(), "/path/on/disk/"+tc.filename, tc.filename)

--- a/pkg/crawl/report.go
+++ b/pkg/crawl/report.go
@@ -191,43 +191,43 @@ func (r *Reporter) Report(ctx context.Context, path Path, result Finding, versio
 	var findingNames []string
 	if result&JndiLookupClassName > 0 && !r.DisableFlaggingJndiLookup {
 		readableReasons = append(readableReasons, "JndiLookup class name matched")
-		findingNames = append(findingNames, "jndiLookupClassName")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JndiLookupClassName))
 	}
 	if result&JndiLookupClassPackageAndName > 0 && !r.DisableFlaggingJndiLookup {
 		readableReasons = append(readableReasons, "JndiLookup class and package name matched")
-		findingNames = append(findingNames, "jndiLookupClassPackageAndName")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JndiLookupClassPackageAndName))
 	}
 	if result&JndiManagerClassName > 0 {
 		readableReasons = append(readableReasons, "JndiManager class name matched")
-		findingNames = append(findingNames, "jndiManagerClassName")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JndiManagerClassName))
 	}
 	if result&JarName > 0 {
 		readableReasons = append(readableReasons, "jar name matched")
-		findingNames = append(findingNames, "jarName")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JarName))
 	}
 	if result&JarNameInsideArchive > 0 {
 		readableReasons = append(readableReasons, "jar name inside archive matched")
-		findingNames = append(findingNames, "jarNameInsideArchive")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JarNameInsideArchive))
 	}
 	if result&JndiManagerClassPackageAndName > 0 {
 		readableReasons = append(readableReasons, "JndiManager class and package name matched")
-		findingNames = append(findingNames, "jndiManagerClassPackageAndName")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JndiManagerClassPackageAndName))
 	}
 	if result&ClassFileMd5 > 0 {
 		readableReasons = append(readableReasons, "class file MD5 matched")
-		findingNames = append(findingNames, "classFileMd5")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(ClassFileMd5))
 	}
 	if result&ClassBytecodeInstructionMd5 > 0 {
 		readableReasons = append(readableReasons, "byte code instruction MD5 matched")
-		findingNames = append(findingNames, "classBytecodeInstructionMd5")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(ClassBytecodeInstructionMd5))
 	}
 	if result&JarFileObfuscated > 0 {
 		readableReasons = append(readableReasons, "jar file appeared obfuscated")
-		findingNames = append(findingNames, "jarFileObfuscated")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(JarFileObfuscated))
 	}
 	if result&ClassBytecodePartialMatch > 0 {
 		readableReasons = append(readableReasons, "byte code partially matched known version")
-		findingNames = append(findingNames, "classBytecodePartialMatch")
+		findingNames = append(findingNames, lowerCamelCaseFindingString(ClassBytecodePartialMatch))
 	}
 
 	var outputToWrite string
@@ -253,6 +253,14 @@ func (r *Reporter) Report(ctx context.Context, path Path, result Finding, versio
 	}
 	_, _ = fmt.Fprintln(r.OutputWriter, outputToWrite)
 	return true
+}
+
+func lowerCamelCaseFindingString(f Finding) string {
+	s := f.String()
+	if len(s) > 1 {
+		return strings.ToLower(string(s[0])) + s[1:]
+	}
+	return s
 }
 
 func (r *Reporter) matchedCVEs(versions []string) []string {

--- a/pkg/crawl/report.go
+++ b/pkg/crawl/report.go
@@ -160,6 +160,7 @@ var cveVersions = []AffectedVersion{
 // The fileCount will be incremented if the finding is a new finding, i.e. a consecutive finding based on the same file when
 // The findingCount will be incremented for every finding reported.
 // OutputFilePathOnly is set to true will not cause the counter to be incremented.
+// The returned boolean will always be true to represent that further inspection of the same file should continue.
 func (r *Reporter) Report(ctx context.Context, path Path, result Finding, versionSet Versions) bool {
 	versions := sortVersions(versionSet)
 	if r.DisableFlaggingUnknownVersions && (len(versions) == 0 || len(versions) == 1 && versions[0] == UnknownVersion) {


### PR DESCRIPTION
Closes https://github.com/palantir/log4j-sniffer/issues/71

Adds a subcommand, `delete`, that crawls the filesystem for vulnerable log4j versions and can delete them based on some configuration supplied by flags.

The command uses the same flags as `crawl` to configure rate limiting of scanning, max archive depth, etc.

Features unique to `delete` are:
* `--filepath-owner` - A filepath regex pattern and templated owner can be provided. When encountering a finding, if the containing filepath matches the pattern provided by `filepath-owner`, then the owner template will be expanded against the filepath match to see if the owner of the file matches.  
This is specifically designed for cases like `^/home/(\w+)/.+:$1` where the owner of a file may depend on the path to it.
* `--skip-owner-check` - Skips any file owner checks. This is required on Windows systems where file ownership seems to be non-trivial.
* `--finding-match` - Specify findings that are required to be found for a vulnerability for the containing file to be deleted.

```
Delete files containing log4j vulnerabilities.

Crawl the file system from root, detecting files containing log4j-vulnerabilities and deleting them if they meet certain requirements determined by the command flags.
Root must be provided and can be a single file or directory.

Dry-run mode is enabled by default, where a line will be output to state where a file would be deleted when running not in dry run mode.
It is recommended to run using dry-run mode enabled, checking the logged output and then running with dry-run disabled using the same configuration flags.
Use --dry-run=false to turn off dry-run mode, enabling deletes.

When used on windows, deleting based on file ownership is unsupported and skip-owner-check should be used instead of filepath-owner.

Usage:
  log4j-sniffer delete <root> [flags]

Examples:
Delete all findings nested beneath /path/to/dir that are owned by foo and contain findings that match both classFileMd5 and jarFileObfuscated.

log4j-sniffer delete /path/to/dir --dry-run=false --filepath-owner ^/path/to/dir/.*:foo --finding-match classFileMd5 --finding-match jarFileObfuscated

Flags:
      --archive-open-mode string                             Supported values:
                                                               standard - standard file opening will be used. This may cause the filesystem cache to be populated with reads from the archive opens.
                                                               directio - direct I/O will be used when opening archives that require sequential reading of their content without being able to skip to file tables at known locations within the file.
                                                                          For example, "directio" can have an effect on the way that tar-based archives are read but will have no effect on zip-based archives.
                                                                          Using "directio" will cause the filesystem cache to be skipped where possible. "directio" is not supported on tmpfs filesystems and will cause tmpfs archive files to report an error. (default "standard")
      --archives-per-second-rate-limit int                   The maximum number of archives to scan per second. 0 for unlimited.
      --directories-per-second-rate-limit int                The maximum number of directories to crawl per second. 0 for unlimited.
      --dry-run                                              When true, a line with be output instead of deleting a file. Use --dry-run=false to enable deletion. (default true)
      --enable-obfuscation-detection                         Enable applying partial bytecode matching to Jars that appear to be obfuscated. (default true)
      --enable-partial-matching-on-all-classes               Enable partial bytecode matching to all class files found.
      --enable-trace-logging                                 Enables trace logging whilst crawling. disable-detailed-findings must be set to false (the default value) for this flag to have an effect.
      --filepath-owner strings                               Provide a filepath pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.
                                                             Multiple values can be provided and values must be provided in the form filepath_pattern:owner_template, where a filepath pattern and owner template are colon separated.

                                                             When a file is deemed to be vulnerable, the path of the file containing the vulnerability will be matched against all filepath patterns.
                                                             For all filepath matches, the owner template will be expanded against the filepath pattern match to resolve to a file owner value that the actual file owner will then be compared against.
                                                             Owner templates may use template variables, e.g. $1, $2, $name, that correspond to capture groups in the filepath pattern. Please refer to the standard go regexp package documentation at https://pkg.go.dev/regexp#Regexp.Expand for more detailed expanding behaviour.

                                                             If no filepaths match, the file will not be deleted. If any filepaths match, all matching filepath patterns' corresponding expanded templated owner values must match against the actual file owner for the file to be deleted.

                                                             Examples:
                                                             --filepath-owner ^/foo/bar/.+:qux would consider /foo/bar/baz for deletion only if it is owned by qux.
                                                             --filepath-owner ^/foo/bar/.+:qux and --filepath-owner ^/foo/bar/baz/.+:quuz would not consider /foo/bar/baz/corge for deletion if owned by either qux or quuz because both would need to match.
                                                             --filepath-owner ^/foo/(\w+)/.*:$1 would consider /foo/bar/baz for deletion only if it is owned by bar.

      --finding-match strings                                When supplied, any vulnerable finding must contain all values that are provided to finding-match for it to be considered for deletion.
                                                             These values are considered on a finding-by-finding basis, i.e. an archive containing two separate vulnerable jars will only be deleted if either of the contained jars matches all finding-match values.

                                                             Supported values are as follows, but can be provided case-insensitively:
                                                             - ClassBytecodeInstructionMd5
                                                             - ClassBytecodePartialMatch
                                                             - ClassFileMd5
                                                             - JarFileObfuscated
                                                             - JarName
                                                             - JarNameInsideArchive
                                                             - JndiLookupClassName
                                                             - JndiLookupClassPackageAndName
                                                             - JndiManagerClassName
                                                             - JndiManagerClassPackageAndName

                                                             Example:
                                                             --finding-match classFileMd5 and --finding-match jarFileObfuscated would only delete a file containing a vulnerability if the vulnerability contains a class file hash match and an obfuscated jar name.
                                                             If a vulnerable finding contained only one of these finding-match values then the file would not be considered for deletion.

  -h, --help                                                 help for delete
      --ignore-dir strings                                   Specify directory pattern to ignore. Use multiple times to supply multiple patterns.
                                                             Patterns should be relative to the provided root.
                                                             e.g. ignore "^/proc" to ignore "/proc" when using a crawl root of "/"
      --maximum-average-obfuscated-class-name-length int     The maximum class name length for a class to be considered obfuscated. (default 3)
      --maximum-average-obfuscated-package-name-length int   The maximum average package name length a class to be considered obfuscated. (default 3)
      --nested-archive-max-depth uint                        The maximum depth to recurse into nested archives.
                                                             A max depth of 0 will open up an archive on the filesystem but not any nested archives.
      --nested-archive-max-size uint                         The maximum compressed size in bytes of any nested archive that will be unarchived for inspection.
                                                             This limit is made a per-depth level.
                                                             The overall limit to nested archive size unarchived should be controlled
                                                             by both the nested-archive-max-size and nested-archive-max-depth. (default 5242880)
      --per-archive-timeout duration                         If this duration is exceeded when inspecting an archive,
                                                             an error will be logged and the crawler will move onto the next file. (default 15m0s)
      --skip-owner-check                                     When provided, the owner of a file will not be checked before attempting a delete.
```