### PR TITLE
Optimise buffer usage in zip walk functions

### DIFF
--- a/changelog/@unreleased/pr-94.v2.yml
+++ b/changelog/@unreleased/pr-94.v2.yml
@@ -1,6 +1,6 @@
 type: improvement
 improvement:
   description: Some optimisations have been made which should reduce the resource
-    overhead required when inspecting zip files (i.e. jars, wars, pars, etc.)
+    overhead required when inspecting zip files, such as .jars, .wars, .pars, etc.
   links:
   - https://github.com/palantir/log4j-sniffer/pull/94

--- a/changelog/@unreleased/pr-94.v2.yml
+++ b/changelog/@unreleased/pr-94.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Some optimisations have been made which should reduce the resource
+    overhead required when inspecting zip files (i.e. jars, wars, pars, etc.)
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/94

--- a/pkg/archive/zip/reader.go
+++ b/pkg/archive/zip/reader.go
@@ -75,9 +75,10 @@ func (z *Reader) walk(r io.ReaderAt, size int64, handleFile WalkFn) error {
 	// a bad one, and then only report an ErrFormat or UnexpectedEOF if
 	// the handleFile count modulo 65536 is incorrect.
 	var numFiles uint64
+	var f File
 	for {
-		f := &File{zip: z, zipr: r}
-		err = readDirectoryHeader(f, buf)
+		f = File{zip: z, zipr: r}
+		err = readDirectoryHeader(&f, buf)
 		if err == ErrFormat || err == io.ErrUnexpectedEOF {
 			break
 		}
@@ -85,7 +86,7 @@ func (z *Reader) walk(r io.ReaderAt, size int64, handleFile WalkFn) error {
 			return err
 		}
 		numFiles++
-		if proceed, err := handleFile(f); err != nil || !proceed {
+		if proceed, err := handleFile(&f); err != nil || !proceed {
 			return err
 		}
 	}

--- a/pkg/archive/zip/reader.go
+++ b/pkg/archive/zip/reader.go
@@ -81,7 +81,7 @@ func (z *Reader) walk(r io.ReaderAt, size int64, handleFile WalkFn) error {
 	var metadatLen int
 	for {
 		f = File{zip: z, zipr: r}
-		metadatLen, err = readDirectoryHeader(&f, buf, dirHeaderBuf, metadataBuf)
+		metadatLen, err = readDirectoryHeader(&f, buf, &dirHeaderBuf, metadataBuf)
 		if err == ErrFormat || err == io.ErrUnexpectedEOF {
 			break
 		}
@@ -296,7 +296,7 @@ func (f *File) findBodyOffset() (int64, error) {
 // readDirectoryHeader attempts to read a directory header from r.
 // It returns io.ErrUnexpectedEOF if it cannot read a complete header,
 // and ErrFormat if it doesn't find a valid header signature.
-func readDirectoryHeader(f *File, r io.Reader, buf [46]byte, i []byte) (int, error) {
+func readDirectoryHeader(f *File, r io.Reader, buf *[46]byte, i []byte) (int, error) {
 	if _, err := io.ReadFull(r, buf[:]); err != nil {
 		return 0, err
 	}

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -959,11 +959,10 @@ func TestIssue8186(t *testing.T) {
 		"PK\x01\x02\x14\x00\x14\x00\b\b\b\x004\x9d3?\xbfP\x96b\x86\x04\x00\x00\xb2\x06\x00\x00\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa9J\x02\x00META-INF/CERT.RSA",
 	}
 
-	var dirHeaderBuf [directoryHeaderLen]byte
 	var metadataBuffer []byte
 	for i, s := range dirEnts {
 		var f File
-		_, err := readDirectoryHeader(&f, strings.NewReader(s), &dirHeaderBuf, &metadataBuffer)
+		_, err := (&Reader{}).readDirectoryHeader(&f, strings.NewReader(s), &metadataBuffer)
 		if err != nil {
 			t.Errorf("error reading #%d: %v", i, err)
 		}

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -1115,9 +1115,9 @@ func TestCVE202127919(t *testing.T) {
 		0x00, 0x00, 0x59, 0x00, 0x00, 0x00, 0x00, 0x00,
 	}
 
-	var fs []*File
+	var fs []File
 	err := WalkZipReaderAt(bytes.NewReader(data), int64(len(data)), func(f *File) (bool, error) {
-		fs = append(fs, f)
+		fs = append(fs, *f)
 		return true, nil
 	})
 	if err != nil {

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -962,7 +962,7 @@ func TestIssue8186(t *testing.T) {
 	}
 	for i, s := range dirEnts {
 		var f File
-		_, err := readDirectoryHeader(&f, strings.NewReader(s), dirHeaderBuf, nil)
+		_, err := readDirectoryHeader(&f, strings.NewReader(s), &dirHeaderBuf, nil)
 		if err != nil {
 			t.Errorf("error reading #%d: %v", i, err)
 		}

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -946,6 +946,8 @@ func returnBigZipBytes() (r io.ReaderAt, size int64) {
 }
 
 func TestIssue8186(t *testing.T) {
+	var dirHeaderBuf [directoryHeaderLen]byte
+
 	// Directory headers & data found in the TOC of a JAR file.
 	dirEnts := []string{
 		"PK\x01\x02\n\x00\n\x00\x00\b\x00\x004\x9d3?\xaa\x1b\x06\xf0\x81\x02\x00\x00\x81\x02\x00\x00-\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00res/drawable-xhdpi-v4/ic_actionbar_accept.png\xfe\xca\x00\x00\x00",
@@ -960,7 +962,7 @@ func TestIssue8186(t *testing.T) {
 	}
 	for i, s := range dirEnts {
 		var f File
-		err := readDirectoryHeader(&f, strings.NewReader(s))
+		_, err := readDirectoryHeader(&f, strings.NewReader(s), dirHeaderBuf, nil)
 		if err != nil {
 			t.Errorf("error reading #%d: %v", i, err)
 		}

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -959,10 +959,9 @@ func TestIssue8186(t *testing.T) {
 		"PK\x01\x02\x14\x00\x14\x00\b\b\b\x004\x9d3?\xbfP\x96b\x86\x04\x00\x00\xb2\x06\x00\x00\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa9J\x02\x00META-INF/CERT.RSA",
 	}
 
-	var metadataBuffer []byte
 	for i, s := range dirEnts {
 		var f File
-		_, err := (&Reader{}).readDirectoryHeader(&f, strings.NewReader(s), &metadataBuffer)
+		err := (&Reader{}).readDirectoryHeader(&f, strings.NewReader(s))
 		if err != nil {
 			t.Errorf("error reading #%d: %v", i, err)
 		}

--- a/pkg/archive/zip/reader_test.go
+++ b/pkg/archive/zip/reader_test.go
@@ -946,8 +946,6 @@ func returnBigZipBytes() (r io.ReaderAt, size int64) {
 }
 
 func TestIssue8186(t *testing.T) {
-	var dirHeaderBuf [directoryHeaderLen]byte
-
 	// Directory headers & data found in the TOC of a JAR file.
 	dirEnts := []string{
 		"PK\x01\x02\n\x00\n\x00\x00\b\x00\x004\x9d3?\xaa\x1b\x06\xf0\x81\x02\x00\x00\x81\x02\x00\x00-\x00\x05\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00res/drawable-xhdpi-v4/ic_actionbar_accept.png\xfe\xca\x00\x00\x00",
@@ -960,9 +958,12 @@ func TestIssue8186(t *testing.T) {
 		"PK\x01\x02\x14\x00\x14\x00\b\b\b\x004\x9d3?\xe6\x98Ьo\x01\x00\x00\x84\x02\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xfcH\x02\x00META-INF/CERT.SF",
 		"PK\x01\x02\x14\x00\x14\x00\b\b\b\x004\x9d3?\xbfP\x96b\x86\x04\x00\x00\xb2\x06\x00\x00\x11\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xa9J\x02\x00META-INF/CERT.RSA",
 	}
+
+	var dirHeaderBuf [directoryHeaderLen]byte
+	var metadataBuffer []byte
 	for i, s := range dirEnts {
 		var f File
-		_, err := readDirectoryHeader(&f, strings.NewReader(s), &dirHeaderBuf, nil)
+		_, err := readDirectoryHeader(&f, strings.NewReader(s), &dirHeaderBuf, &metadataBuffer)
 		if err != nil {
 			t.Errorf("error reading #%d: %v", i, err)
 		}


### PR DESCRIPTION
We can reuse buffers in the Reader struct to reduce the number of allocations when walking a zip.
The pointer passed to the handler will now point to the same memory address but we have already stated that the file should only be used during the duration of the WalkFn callback so this is fine.

The largest improvements are for zips containing many files but we still get a 15% speedup from zips containing as little as 10 files. These optimisations only improve the overhead of scanning a zip file, not processing contents etc.

```
$ benchstat /tmp/before /tmp/after
name                       old time/op    new time/op    delta
WalkZipReaderAt/10-16        6.03µs ± 1%    5.09µs ± 3%  -15.66%  (p=0.004 n=5+6)
WalkZipReaderAt/100-16       24.2µs ± 1%    14.8µs ± 2%  -39.03%  (p=0.002 n=6+6)
WalkZipReaderAt/1000-16       215µs ± 2%     109µs ± 0%  -49.25%  (p=0.004 n=6+5)
WalkZipReaderAt/10000-16     2.31ms ± 1%    1.11ms ± 1%  -51.76%  (p=0.004 n=6+5)
WalkZipReaderAt/100000-16    21.6ms ± 2%    11.7ms ± 2%  -46.06%  (p=0.002 n=6+6)

name                       old alloc/op   new alloc/op   delta
WalkZipReaderAt/10-16        8.08kB ± 0%    5.70kB ± 0%  -29.50%  (p=0.002 n=6+6)
WalkZipReaderAt/100-16       30.0kB ± 0%     5.9kB ± 0%  -80.45%  (p=0.002 n=6+6)
WalkZipReaderAt/1000-16       252kB ± 0%       9kB ± 0%  -96.51%  (p=0.002 n=6+6)
WalkZipReaderAt/10000-16     2.48MB ± 0%    0.04MB ± 0%  -98.20%  (p=0.000 n=5+6)
WalkZipReaderAt/100000-16    25.0MB ± 0%     0.5MB ± 0%  -97.90%  (p=0.002 n=6+6)

name                       old allocs/op  new allocs/op  delta
WalkZipReaderAt/10-16          39.0 ± 0%       9.0 ± 0%  -76.92%  (p=0.002 n=6+6)
WalkZipReaderAt/100-16          399 ± 0%       100 ± 0%  -74.94%  (p=0.002 n=6+6)
WalkZipReaderAt/1000-16       4.00k ± 0%     1.00k ± 0%  -74.93%  (p=0.002 n=6+6)
WalkZipReaderAt/10000-16      40.0k ± 0%     10.0k ± 0%  -74.99%  (p=0.002 n=6+6)
WalkZipReaderAt/100000-16      400k ± 0%      100k ± 0%  -75.00%  (p=0.002 n=6+6)
```