### PR TITLE
Use full filepath for filepath match

### DIFF
--- a/changelog/@unreleased/pr-97.v2.yml
+++ b/changelog/@unreleased/pr-97.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: A small bug has been fixed where only the directory of a filepath would
+    be passed for pattern matching rather than the whole file when using `--filepath-owner`.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/97

--- a/internal/deleter/templatedowner.go
+++ b/internal/deleter/templatedowner.go
@@ -15,7 +15,6 @@
 package deleter
 
 import (
-	"path/filepath"
 	"regexp"
 )
 
@@ -28,7 +27,7 @@ type TemplatedOwner struct {
 
 // FilepathMatch returns true when the filepath of the finding matches the TemplatedOwner FilepathExpression field.
 func (r TemplatedOwner) FilepathMatch(path string) bool {
-	return r.FilepathExpression.MatchString(filepath.Dir(path))
+	return r.FilepathExpression.MatchString(path)
 }
 
 // OwnerMatch returns true when owner of the file matches the result of the OwnerTemplate being expanded against the

--- a/internal/deleter/templatedowner_test.go
+++ b/internal/deleter/templatedowner_test.go
@@ -31,9 +31,9 @@ func TestRegexWithSubstitutionMatcher(t *testing.T) {
 
 	t.Run("makes substitution for owner match", func(t *testing.T) {
 		matcher := TemplatedOwner{
-			FilepathExpression: regexp.MustCompile("/foo/(.+)/"),
+			FilepathExpression: regexp.MustCompile("/foo/bar/(.+)"),
 			OwnerTemplate:      "owner $1",
 		}
-		assert.True(t, matcher.OwnerMatch("/foo/bar/baz", "owner bar"))
+		assert.True(t, matcher.OwnerMatch("/foo/bar/baz", "owner baz"))
 	})
 }


### PR DESCRIPTION
In https://github.com/palantir/log4j-sniffer/pull/93 there was a small bug introduced where the directory rather than whole filepath would be considered for the `--filepath-owner` option.