### PR TITLE
Support disabling deletion of certain CVEs

### DIFF
--- a/changelog/@unreleased/pr-100.v2.yml
+++ b/changelog/@unreleased/pr-100.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Support disabling deletion of certain CVEs
+
+    `--disable-cve-2021-45105-detection` and `--disable-cve-2021-44832-detection` flags have been added to the delete command to allow for deleting only findings that map to certain CVEs. Some vulnerable files will contain multiple CVEs and so it is advised that the desired combination of `--disable-cve-*` flags be found by running with `--dry-run=true` (which is the default value) first.
+  links:
+  - https://github.com/palantir/log4j-sniffer/pull/100

--- a/cmd/crawl.go
+++ b/cmd/crawl.go
@@ -27,9 +27,8 @@ import (
 func crawlCmd() *cobra.Command {
 	var (
 		cmdCrawlFlags             crawlFlags
+		cmdCVEFlags               cveFlags
 		disableDetailedFindings   bool
-		disableCVE45105           bool
-		disableCVE44832           bool
 		disableFlaggingJndiLookup bool
 		disableUnknownVersions    bool
 		outputJSON                bool
@@ -55,8 +54,7 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 				OutputJSON:                     outputJSON,
 				OutputFilePathOnly:             outputFilePathOnly,
 				OutputWriter:                   cmd.OutOrStdout(),
-				DisableCVE45105:                disableCVE45105,
-				DisableCVE44832:                disableCVE44832,
+				CVEResolver:                    cmdCVEFlags.cveResolver(),
 				DisableFlaggingJndiLookup:      disableFlaggingJndiLookup,
 				DisableFlaggingUnknownVersions: disableUnknownVersions,
 			}
@@ -92,10 +90,10 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 				} else {
 					var cveInfo string
 					cveInfo = "CVE-2021-44228 or CVE-2021-45046"
-					if !disableCVE45105 {
+					if !cmdCVEFlags.disableCVE45105 {
 						cveInfo += " or CVE-2021-45105"
 					}
-					if !disableCVE44832 {
+					if !cmdCVEFlags.disableCVE44832 {
 						cveInfo += " or CVE-2021-44832"
 					}
 					count := reporter.FileCount()
@@ -114,11 +112,10 @@ Use the ignore-dir flag to provide directories of which to ignore all nested fil
 	}
 
 	applyCrawlFlags(&cmd, &cmdCrawlFlags)
+	applyCVEFlags(&cmd, &cmdCVEFlags)
 	cmd.Flags().BoolVar(&disableDetailedFindings, "disable-detailed-findings", false, "Do not print out detailed finding information when not outputting in JSON.")
 	cmd.Flags().BoolVar(&disableFlaggingJndiLookup, "disable-flagging-jndi-lookup", false, `Do not report results that only match on the presence of a JndiLookup class.
 Even when disabled results which match other criteria will still report the presence of JndiLookup if relevant.`)
-	cmd.Flags().BoolVar(&disableCVE45105, "disable-cve-2021-45105-detection", false, `Disable detection of CVE-2021-45105 in versions up to 2.16.0`)
-	cmd.Flags().BoolVar(&disableCVE44832, "disable-cve-2021-44832-detection", false, `Disable detection of CVE-2021-44832 in versions up to 2.17.0`)
 	cmd.Flags().BoolVar(&disableUnknownVersions, "disable-unknown-versions", false, `Only output issues if the version of log4j can be determined (note that this will cause certain detection mechanisms to be skipped)`)
 	cmd.Flags().BoolVar(&outputJSON, "json", false, "If true, output will be in JSON format")
 	cmd.Flags().BoolVar(&outputFilePathOnly, "file-path-only", false, "If true, output will consist of only paths to the files in which CVEs are detected")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -32,6 +32,7 @@ import (
 func deleteCmd() *cobra.Command {
 	var (
 		cmdCrawlFlags   crawlFlags
+		cmdCVEFlags     cveFlags
 		dryRun          bool
 		skipOwnerCheck  bool
 		filepathOwners  []string
@@ -82,12 +83,14 @@ When used on windows, deleting based on file ownership is unsupported and skip-o
 				Logger:        logger(cmd, cmdCrawlFlags),
 				FilepathMatch: filepathMatch,
 				FindingMatch:  findingMatch,
+				VersionsMatch: deleter.VersionMatcher(cmdCVEFlags.cveResolver()),
 				DryRun:        dryRun,
 			}.Process, cmd.OutOrStdout(), cmd.OutOrStderr())
 			return err
 		},
 	}
 	applyCrawlFlags(&cmd, &cmdCrawlFlags)
+	applyCVEFlags(&cmd, &cmdCVEFlags)
 	cmd.Flags().BoolVar(&dryRun, "dry-run", true, "When true, a line with be output instead of deleting a file. Use --dry-run=false to enable deletion.")
 	cmd.Flags().BoolVar(&skipOwnerCheck, "skip-owner-check", false, "When provided, the owner of a file will not be checked before attempting a delete.")
 	cmd.Flags().StringSliceVar(&filepathOwners, "filepath-owner", nil, `Provide a filepath pattern and owner template that will be used to check whether a file should be deleted or not when it is deemed to be vulnerable.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/palantir/log4j-sniffer/internal/crawler"
 	"github.com/palantir/log4j-sniffer/pkg/archive"
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -124,4 +125,25 @@ func (fs crawlFlags) resolveIgnoreDirs() ([]*regexp.Regexp, error) {
 		ignores = append(ignores, compiled)
 	}
 	return ignores, nil
+}
+
+type cveFlags struct {
+	disableCVE45105 bool
+	disableCVE44832 bool
+}
+
+func (fs cveFlags) cveResolver() crawl.CVEResolver {
+	var cveResolver crawl.CVEResolver
+	if fs.disableCVE44832 {
+		cveResolver.IgnoreCVES = append(cveResolver.IgnoreCVES, crawl.CVE202144832)
+	}
+	if fs.disableCVE45105 {
+		cveResolver.IgnoreCVES = append(cveResolver.IgnoreCVES, crawl.CVE202145105)
+	}
+	return cveResolver
+}
+
+func applyCVEFlags(cmd *cobra.Command, flags *cveFlags) {
+	cmd.Flags().BoolVar(&flags.disableCVE45105, "disable-cve-2021-45105-detection", false, `Disable detection of CVE-2021-45105 in versions up to 2.16.0`)
+	cmd.Flags().BoolVar(&flags.disableCVE44832, "disable-cve-2021-44832-detection", false, `Disable detection of CVE-2021-44832 in versions up to 2.17.0`)
 }

--- a/internal/deleter/delete.go
+++ b/internal/deleter/delete.go
@@ -27,6 +27,7 @@ type Deleter struct {
 	Logger        log.Logger
 	FilepathMatch func(filepath string) (bool, error)
 	FindingMatch  func(finding crawl.Finding) bool
+	VersionsMatch func(versions crawl.Versions) bool
 	DryRun        bool
 }
 
@@ -39,7 +40,7 @@ type Deleter struct {
 // nil FilepathMatch and nil FindingMatch functions will act as match alls, asif returning true for all inputs.
 // When Deleter.DryRun is true then a line will be logged stating that the file would be deleted.
 // When Deleter.Delete is false, then the configured function Delete will be called to delete the file.
-func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Finding, _ crawl.Versions) bool {
+func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Finding, versions crawl.Versions) bool {
 	if len(path) == 0 {
 		return true
 	}
@@ -55,6 +56,9 @@ func (d Deleter) Process(ctx context.Context, path crawl.Path, finding crawl.Fin
 		}
 	}
 	if d.FindingMatch != nil && !d.FindingMatch(finding) {
+		return true
+	}
+	if d.VersionsMatch != nil && !d.VersionsMatch(versions) {
 		return true
 	}
 	if d.DryRun {

--- a/internal/deleter/version.go
+++ b/internal/deleter/version.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter
+
+import (
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+)
+
+// CVEResolver resolves Log4jVersions to CVEs
+type CVEResolver interface {
+	CVEs(vs []crawl.Log4jVersion) []string
+}
+
+// VersionMatcher creates a function that will return true only when CVEs are present for a
+// set of Versions.
+// All Versions will be parsed to extract the log4j version found for them, the valid found
+// versions will be resolved to matching CVEs using the CVEResolver.
+// If any CVEs are present, the returned bool will be true to represent that the file containing
+// the CVEs should be deleted.
+func VersionMatcher(cveResolver CVEResolver) func(versions crawl.Versions) bool {
+	return func(versions crawl.Versions) bool {
+		// ignore fact that there may have been invalid versions
+		vs, _ := crawl.ParseLog4jVersions(versions)
+		return cveResolver != nil && len(cveResolver.CVEs(vs)) > 0
+	}
+}

--- a/internal/deleter/version_test.go
+++ b/internal/deleter/version_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deleter_test
+
+import (
+	"testing"
+
+	"github.com/palantir/log4j-sniffer/internal/deleter"
+	"github.com/palantir/log4j-sniffer/pkg/crawl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionMatcher(t *testing.T) {
+	t.Run("no valid versions do not match", func(t *testing.T) {
+		assert.False(t, deleter.VersionMatcher(nil)(nil))
+	})
+
+	t.Run("nil version resolver returns false", func(t *testing.T) {
+		match := deleter.VersionMatcher(nil)
+		assert.False(t, match(crawl.Versions{"1.2.3": {}}))
+	})
+
+	t.Run("versions passed to resolver", func(t *testing.T) {
+		var versions []crawl.Log4jVersion
+		match := deleter.VersionMatcher(stubbedCVEResolver(func(vs []crawl.Log4jVersion) []string {
+			versions = vs
+			return nil
+		}))
+		assert.False(t, match(crawl.Versions{"1.2.3": {}}))
+		assert.Equal(t, []crawl.Log4jVersion{{
+			Original: "1.2.3",
+			Major:    1,
+			Minor:    2,
+			Patch:    3,
+		}}, versions)
+	})
+
+	t.Run("no cves returns false", func(t *testing.T) {
+		match := deleter.VersionMatcher(stubbedCVEResolver(func(vs []crawl.Log4jVersion) []string { return nil }))
+		assert.False(t, match(crawl.Versions{"1.2.3": {}}))
+	})
+
+	t.Run("some cves returns true", func(t *testing.T) {
+		match := deleter.VersionMatcher(stubbedCVEResolver(func(vs []crawl.Log4jVersion) []string { return []string{"foo"} }))
+		assert.True(t, match(crawl.Versions{"1.2.3": {}}))
+	})
+}
+
+type stubbedCVEResolver func([]crawl.Log4jVersion) []string
+
+func (s stubbedCVEResolver) CVEs(vs []crawl.Log4jVersion) []string {
+	return s(vs)
+}

--- a/pkg/crawl/cve.go
+++ b/pkg/crawl/cve.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"sort"
+)
+
+const (
+	CVE202145105 = CVEID("CVE-2021-45105")
+	CVE202144228 = CVEID("CVE-2021-44228")
+	CVE202145046 = CVEID("CVE-2021-45046")
+	CVE202144832 = CVEID("CVE-2021-44832")
+)
+
+type CVEID string
+
+var cveVersions = []AffectedVersion{
+	{
+		CVE: CVE202144228,
+		FixedAfter: Log4jVersion{
+			Major: 2,
+			Minor: 16,
+			Patch: 0,
+		},
+		PatchedVersions: []Log4jVersion{
+			{
+				Major: 2,
+				Minor: 12,
+				Patch: 2,
+			},
+			{
+				Major: 2,
+				Minor: 3,
+				Patch: 1,
+			},
+		},
+	},
+	{
+		CVE: CVE202145046,
+		FixedAfter: Log4jVersion{
+			Major: 2,
+			Minor: 16,
+			Patch: 0,
+		},
+		PatchedVersions: []Log4jVersion{
+			{
+				Major: 2,
+				Minor: 12,
+				Patch: 2,
+			},
+			{
+				Major: 2,
+				Minor: 3,
+				Patch: 1,
+			},
+		},
+	},
+	{
+		CVE: CVE202145105,
+		FixedAfter: Log4jVersion{
+			Major: 2,
+			Minor: 17,
+			Patch: 0,
+		},
+		PatchedVersions: []Log4jVersion{
+			{
+				Major: 2,
+				Minor: 12,
+				Patch: 3,
+			},
+			{
+				Major: 2,
+				Minor: 3,
+				Patch: 1,
+			},
+		},
+	},
+	{
+		CVE: CVE202144832,
+		FixedAfter: Log4jVersion{
+			Major: 2,
+			Minor: 17,
+			Patch: 1,
+		},
+		PatchedVersions: []Log4jVersion{
+			{
+				Major: 2,
+				Minor: 12,
+				Patch: 4,
+			},
+			{
+				Major: 2,
+				Minor: 3,
+				Patch: 2,
+			},
+		},
+	},
+}
+
+type AffectedVersion struct {
+	CVE             CVEID
+	FixedAfter      Log4jVersion
+	PatchedVersions []Log4jVersion
+}
+
+// CVEResolver resolves the CVEs for log4j versions.
+type CVEResolver struct {
+	// IgnoreCVES contains the IDs of CVEs that will be omitted to CVE results.
+	IgnoreCVES []CVEID
+}
+
+func (r CVEResolver) CVEs(vs []Log4jVersion) []string {
+	cves := make(map[CVEID]struct{})
+	for _, v := range vs {
+		for _, vulnerability := range cveVersions {
+			if v.Major >= vulnerability.FixedAfter.Major && v.Minor >= vulnerability.FixedAfter.Minor && v.Patch >= vulnerability.FixedAfter.Patch {
+				continue
+			}
+			vulnerable := true
+			for _, fixedVersion := range vulnerability.PatchedVersions {
+				if v.Major == fixedVersion.Major && v.Minor == fixedVersion.Minor && v.Patch >= fixedVersion.Patch {
+					vulnerable = false
+					break
+				}
+			}
+			if vulnerable && r.included(vulnerability.CVE) {
+				cves[vulnerability.CVE] = struct{}{}
+			}
+		}
+	}
+	var uniqueCVEs []string
+	for cve := range cves {
+		uniqueCVEs = append(uniqueCVEs, string(cve))
+	}
+	sort.Strings(uniqueCVEs)
+	return uniqueCVEs
+}
+
+func (r CVEResolver) included(cveID CVEID) bool {
+	for _, ignoredCVE := range r.IgnoreCVES {
+		if cveID == ignoredCVE {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/crawl/cve_test.go
+++ b/pkg/crawl/cve_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLog4jVersion(t *testing.T) {
+	t.Run("no match returns false", func(t *testing.T) {
+		_, parsed := ParseLog4jVersion("")
+		assert.False(t, parsed)
+	})
+
+	for _, tc := range []struct {
+		name          string
+		version       string
+		parsedVersion Log4jVersion
+	}{{
+		name:    "major, minor",
+		version: "98.99",
+		parsedVersion: Log4jVersion{
+			Major:    98,
+			Minor:    99,
+			Original: "98.99",
+		},
+	}, {
+		name:    "major, minor, patch",
+		version: "97.98.99",
+		parsedVersion: Log4jVersion{
+			Major:    97,
+			Minor:    98,
+			Patch:    99,
+			Original: "97.98.99",
+		},
+	}, {
+		name:    "major, minor, patch, extra",
+		version: "97.98.99-foo",
+		parsedVersion: Log4jVersion{
+			Major:    97,
+			Minor:    98,
+			Patch:    99,
+			Original: "97.98.99-foo",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			v, parsed := ParseLog4jVersion(tc.version)
+			assert.True(t, parsed)
+			assert.Equal(t, tc.parsedVersion, v)
+		})
+	}
+}

--- a/pkg/crawl/finding.go
+++ b/pkg/crawl/finding.go
@@ -56,7 +56,23 @@ var (
 )
 
 type Finding int
+
 type Versions map[string]struct{}
+
+func (vs Versions) contains(v string) bool {
+	_, ok := vs[v]
+	return ok
+}
+
+func (vs Versions) SortedList() []string {
+	var out []string
+	for v := range vs {
+		out = append(out, v)
+	}
+	// N.B. Lexical sort will mess with base-10 versions, but it's better than random.
+	sort.Strings(out)
+	return out
+}
 
 // FindingOf creates a finding from a string, returning an error if a corresponding finding does not exist.
 // Conversion is case-insensitive.

--- a/pkg/crawl/identify_test.go
+++ b/pkg/crawl/identify_test.go
@@ -188,7 +188,7 @@ func TestIdentifyFromFileName(t *testing.T) {
 			version, match := crawl.FileNameMatchesLog4jJar(tc.in)
 			require.Equal(t, tc.version != "", match)
 			if match {
-				assert.Equal(t, tc.version, version)
+				assert.Equal(t, tc.version, version.Original)
 			}
 		})
 	}

--- a/pkg/crawl/version.go
+++ b/pkg/crawl/version.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crawl
+
+import (
+	"regexp"
+	"strconv"
+)
+
+var log4jVersionRegex = regexp.MustCompile(`(?i)^(\d+)\.(\d+)\.?(\d+)?(?:[\./-].*)?$`)
+
+// ParseLog4jVersions parses all Versions represented as strings, returning a slice of all valid versions found.
+// A bool is returned that will be true if there were any invalid versions provided and the invalid versions will
+// be omitted from the returns Log4jVersion slice.
+func ParseLog4jVersions(versions Versions) ([]Log4jVersion, bool) {
+	var out []Log4jVersion
+	var includesInvalid bool
+	for v := range versions {
+		parsedV, parsed := ParseLog4jVersion(v)
+		if !parsed {
+			includesInvalid = true
+			continue
+		}
+		out = append(out, parsedV)
+	}
+	return out, includesInvalid
+}
+
+func ParseLog4jVersion(version string) (Log4jVersion, bool) {
+	matches := log4jVersionRegex.FindStringSubmatch(version)
+	if len(matches) == 0 {
+		return Log4jVersion{}, false
+	}
+	major, err := strconv.Atoi(matches[1])
+	if err != nil {
+		// should not be possible due to group of \d+ in regex
+		return Log4jVersion{}, false
+	}
+	minor, err := strconv.Atoi(matches[2])
+	if err != nil {
+		// should not be possible due to group of \d+ in regex
+		return Log4jVersion{}, false
+	}
+	patch, err := strconv.Atoi(matches[3])
+	if err != nil {
+		patch = 0
+	}
+	return Log4jVersion{
+		Original: version,
+		Major:    major,
+		Minor:    minor,
+		Patch:    patch,
+	}, true
+}
+
+type Log4jVersion struct {
+	Original string
+	Major    int
+	Minor    int
+	Patch    int
+}
+
+func (v Log4jVersion) Vulnerable() bool {
+	return (v.Major == 2 && v.Minor <= 17) && !(v.Minor == 17 && v.Patch >= 1) && !(v.Minor == 12 && v.Patch >= 4) && !(v.Minor == 3 && v.Patch >= 2)
+}


### PR DESCRIPTION
`--disable-cve-2021-45105-detection` and `--disable-cve-2021-44832-detection` flags have been added to the delete command to allow for deleting only findings that map to certain CVEs. The solution has been done in this manner so that the flags remain the same across the `crawl` and `delete` subcommands, although it would probably be cleaner to implement a flag of the form `--include-cve` or `--ignore-cve` which could be an additive or subtractive CVE list. This change would not be hard to do and I'm happy to do that if we are willing to either make break or maintain some deprecated flag values.

Changes include:
* Extracted out common CVE flags for use in `crawl` and `delete` and a CVEResolver type that can be configured to ignore CVE-2021-45105 and CVE-2021-44832.
* Adds a `VersionMatch` to the `Deleter` which will block deletion of a finding unless the VersionMatch function resolves to true.
  * For the delete command, the VersionMatch function will cause findings to deleted when the valid findings versions have CVEs present, with the option to ignore the two CVEs mentioned above. If a finding has one of the CVEs configured to ignore and other CVEs are still contained within the finding, then the finding can still be deleted.
* Much of the CVE and Log4jVersion code has been put into separate files to make the project tidier.
* Some of the codepaths have had string versions replaced with parsing to `Log4JVersion` to make the codepaths more understandable when it comes to handling of unknown or invalid versions.
  * Specifically on the point above, with the `Reporter.Report` method, the original behaviour has been maintained, where strings containing `"unknown version - unknown CVE status"` and `"invalid version - unknown CVE status"` can still be populated in the `cvesFound` slice. I kept this here to maintain backwards compatibility but I am not opposed to making some simple changes here as I find this behaviour a little confusing tbh.